### PR TITLE
Replace text-based icons with SF Symbol-style SVGs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -141,8 +141,7 @@ textarea{resize:vertical;min-height:56px}
 
 /* ── Hamburger ── */
 .hbg-wrap{position:relative;display:inline-block}
-.hbg-btn{width:36px;height:36px;border:0.5px solid rgba(0,0,0,0.35);border-radius:var(--radius);background:#ffffff;cursor:pointer;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px}
-.hbg-btn span{display:block;width:16px;height:1.5px;background:#4a4945;border-radius:1px}
+.hbg-btn{width:36px;height:36px;border:0.5px solid rgba(0,0,0,0.35);border-radius:var(--radius);background:#ffffff;cursor:pointer;display:flex;align-items:center;justify-content:center;color:#4a4945}
 .hbg-menu{display:none;position:absolute;right:0;top:42px;background:#ffffff;border:0.5px solid rgba(0,0,0,0.35);border-radius:var(--radius-lg);min-width:160px;z-index:200;padding:6px 0;box-shadow:0 8px 24px rgba(0,0,0,.12)}
 .hbg-menu.open{display:block}
 .hbg-item{display:flex;align-items:center;padding:12px 16px;font-size:14px;color:#111110;cursor:pointer;border:none;background:transparent;width:100%;text-align:left;font-family:inherit}
@@ -280,9 +279,9 @@ textarea{resize:vertical;min-height:56px}
       <div class="inn-sub" id="inn-sub"></div>
     </div>
     <div class="inn-right">
-      <button class="btn btn-sm" style="border-color:#b5d4f4;color:#185fa5;background:#f0f7ff" onclick="confirmEndHalf()">End half →</button>
+      <button class="btn btn-sm" style="border-color:#b5d4f4;color:#185fa5;background:#f0f7ff" onclick="confirmEndHalf()">End half <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4,1 9,6 4,11"/></svg></button>
       <div class="hbg-wrap">
-        <button class="hbg-btn" onclick="toggleHbg()"><span></span><span></span><span></span></button>
+        <button class="hbg-btn" onclick="toggleHbg()"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg></button>
         <div class="hbg-menu" id="hbg-menu">
           <button class="hbg-item" onclick="closeHbg();showStats()">Quick stats</button>
           <button class="hbg-item" onclick="closeHbg();goSummary()">Game summary</button>
@@ -341,7 +340,7 @@ textarea{resize:vertical;min-height:56px}
 <!-- ══ SUMMARY ══ -->
 <div id="screen-summary" class="screen">
   <div style="display:flex;align-items:center;gap:9px;margin-bottom:.95rem">
-    <button class="btn btn-sm" onclick="showScreen('game')">← Back</button>
+    <button class="btn btn-sm" onclick="showScreen('game')"><svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:2px"><polyline points="8,1 3,6 8,11"/></svg>Back</button>
     <h2 style="margin-bottom:0">Game summary</h2>
   </div>
   <div class="card">
@@ -384,7 +383,7 @@ textarea{resize:vertical;min-height:56px}
 <!-- ══ EXPORT ══ -->
 <div id="screen-export" class="screen">
   <div style="display:flex;align-items:center;gap:9px;margin-bottom:.95rem">
-    <button class="btn btn-sm" onclick="showScreen('summary')">← Back</button>
+    <button class="btn btn-sm" onclick="showScreen('summary')"><svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:2px"><polyline points="8,1 3,6 8,11"/></svg>Back</button>
     <h2 style="margin-bottom:0">Export summary</h2>
   </div>
   <div id="export-box"></div>
@@ -401,7 +400,7 @@ textarea{resize:vertical;min-height:56px}
     <div style="display:flex;gap:7px;align-items:center">
       <button class="btn btn-sm btn-primary" onclick="goSetup()">+ New game</button>
       <div class="hbg-wrap">
-        <button class="hbg-btn" onclick="toggleHistHbg()"><span></span><span></span><span></span></button>
+        <button class="hbg-btn" onclick="toggleHistHbg()"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg></button>
         <div class="hbg-menu" id="hist-hbg-menu">
           <button class="hbg-item" onclick="closeHistHbg();showScreen('config')">Configuration</button>
           <button class="hbg-item" onclick="closeHistHbg();exportAllGames()">Export games</button>
@@ -416,7 +415,7 @@ textarea{resize:vertical;min-height:56px}
 <!-- ══ CONFIG ══ -->
 <div id="screen-config" class="screen">
   <div style="display:flex;align-items:center;gap:9px;margin-bottom:.5rem">
-    <button class="btn btn-sm" onclick="showScreen('history')">← Back</button>
+    <button class="btn btn-sm" onclick="showScreen('history')"><svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:2px"><polyline points="8,1 3,6 8,11"/></svg>Back</button>
     <h2 style="margin-bottom:0">Configuration</h2>
   </div>
   <p class="sub">Manage pitch and catcher threshold presets and your field list.</p>
@@ -515,7 +514,7 @@ function showModal(title, sub, actions, dismissable) {
   const ov = document.createElement('div'); ov.className = 'modal-overlay'; ov.id = 'active-modal';
   if (dismissable) ov.addEventListener('click', e => { if (e.target === ov) closeModal(); });
   const btns = actions.map(a => `<button class="btn ${a.cls||''}" style="flex:1" onclick="${a.fn}">${a.label}</button>`).join('');
-  const xBtn = dismissable ? `<button class="modal-close-x" onclick="closeModal()">✕</button>` : '';
+  const xBtn = dismissable ? `<button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>` : '';
   ov.innerHTML = `<div class="modal-box">${xBtn}<div class="modal-title">${title}</div><div class="modal-sub">${sub}</div><div class="modal-actions">${btns}</div></div>`;
   document.body.appendChild(ov);
 }
@@ -569,7 +568,7 @@ function showConfigPickerForSetup() {
       <div style="font-size:12px;color:#4a4945">Max ${cfg.pitchMax} pitches · ${cfg.catcherInnMax} catcher innings</div></div>
       ${cfg.id === state.activeConfigId ? '<span class="badge b-blue">Selected</span>' : ''}
     </div>`).join('');
-  modal.innerHTML = `<div class="modal-box"><button class="modal-close-x" onclick="closeModal()">✕</button><div class="modal-title" style="margin-bottom:10px">Select configuration</div>${rows}</div>`;
+  modal.innerHTML = `<div class="modal-box"><button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button><div class="modal-title" style="margin-bottom:10px">Select configuration</div>${rows}</div>`;
   document.body.appendChild(modal);
 }
 function selectConfigForSetup(id) {
@@ -674,8 +673,9 @@ function endHalfInning() {
 // Batter alert
 function batterAlertHtml(count) {
   if (count < BATTER_WARN) return '';
-  if (count >= BATTER_CRIT) return `<div class="a-critical"><div class="ai">!</div><div><strong>High pitch count on this batter (${count})</strong> — verify count is correct. Tracking continues.</div></div>`;
-  return `<div class="alert a-warn"><div class="ai">!</div><span>Batter pitch count is ${count} — verify count is correct or press Next batter.</span></div>`;
+  const warnSvg = '<svg width="10" height="10" viewBox="0 0 10 10"><path d="M5 1v5M5 8v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg>';
+  if (count >= BATTER_CRIT) return `<div class="a-critical"><div class="ai">${warnSvg}</div><div><strong>High pitch count on this batter (${count})</strong> — verify count is correct. Tracking continues.</div></div>`;
+  return `<div class="alert a-warn"><div class="ai">${warnSvg}</div><span>Batter pitch count is ${count} — verify count is correct or press Next batter.</span></div>`;
 }
 
 // Pitch alerts — uses active config thresholds if available
@@ -715,7 +715,7 @@ function restInfo(p) {
   for (const thr of thresholds) { if (p <= thr.pitches) return { days: thr.days, label: thr.days === 0 ? 'No rest required' : `${thr.days} day${thr.days > 1 ? 's' : ''} rest required` }; }
   return { days: 2, label: '2 days rest required' };
 }
-function alertHtml(a) { const cls = a.t === 'danger' ? 'a-danger' : a.t === 'warn' ? 'a-warn' : 'a-info'; const ic = a.t === 'danger' || a.t === 'warn' ? '!' : 'i'; return `<div class="alert ${cls}"><div class="ai">${ic}</div><span>${a.m}</span></div>`; }
+function alertHtml(a) { const cls = a.t === 'danger' ? 'a-danger' : a.t === 'warn' ? 'a-warn' : 'a-info'; const ic = a.t === 'danger' || a.t === 'warn' ? '<svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><path d="M5 1v5M5 8v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg>' : '<svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><path d="M5 3v.5M5 5v3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg>'; return `<div class="alert ${cls}"><div class="ai">${ic}</div><span>${a.m}</span></div>`; }
 
 const UNDO_SVG = `<svg class="undo-icon" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2 5H8.5C10.433 5 12 6.567 12 8.5C12 10.433 10.433 12 8.5 12H5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M4.5 2.5L2 5L4.5 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
 
@@ -757,7 +757,7 @@ function renderPitcherSection() {
     <div class="hero-rest" style="color:${rcol}">${ri ? ri.label : 'No rest required'}</div>
   </div>`;
   h += `<div class="action-row"><button class="big-btn pitch" onclick="addPitch()">+ Pitch</button><button class="undo-btn" onclick="undoLast()" ${undoLen === 0 ? 'disabled' : ''}>${UNDO_SVG} Undo</button></div>`;
-  h += `<button class="big-btn next-b" onclick="nextBatter()" style="margin-bottom:0">Next batter →</button>`;
+  h += `<button class="big-btn next-b" onclick="nextBatter()" style="margin-bottom:0">Next batter <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4,1 9,6 4,11"/></svg></button>`;
   // No inning dots — removed per change #8
   document.getElementById('pitcher-display').innerHTML = h;
 }
@@ -768,7 +768,7 @@ function editPitcher(i) {
   const modal = document.createElement('div'); modal.className = 'modal-overlay'; modal.id = 'active-modal';
   modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
   modal.innerHTML = `<div class="modal-box">
-    <button class="modal-close-x" onclick="closeModal()">✕</button>
+    <button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>
     <div class="modal-title">Edit pitcher</div>
     <div style="display:flex;gap:8px;margin-bottom:14px;margin-top:4px">
       <div style="flex:2"><div class="lbl">Name</div><input type="text" id="edit-p-name" value="${p.name}" placeholder="Pitcher name"></div>
@@ -796,7 +796,7 @@ function editCatcher(i) {
   const modal = document.createElement('div'); modal.className = 'modal-overlay'; modal.id = 'active-modal';
   modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
   modal.innerHTML = `<div class="modal-box">
-    <button class="modal-close-x" onclick="closeModal()">✕</button>
+    <button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>
     <div class="modal-title">Edit catcher</div>
     <div style="display:flex;gap:8px;margin-bottom:14px;margin-top:4px">
       <div style="flex:2"><div class="lbl">Name</div><input type="text" id="edit-c-name" value="${c.name}" placeholder="Catcher name"></div>
@@ -825,7 +825,7 @@ function showEditPitchCount() {
   const modal = document.createElement('div'); modal.className = 'modal-overlay'; modal.id = 'active-modal';
   modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
   modal.innerHTML = `<div class="modal-box">
-    <button class="modal-close-x" onclick="closeModal()">✕</button>
+    <button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>
     <div class="modal-title">Edit pitch count</div>
     <div class="modal-sub">Correct the pitch count for ${p.name}${p.num ? ' #' + p.num : ''}. Use this to fix miscounts.</div>
     <div style="margin-bottom:14px">
@@ -1184,7 +1184,7 @@ function openExportForGame(gi) {
   const modal = document.createElement('div'); modal.className = 'modal-overlay'; modal.id = 'active-modal';
   modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
   modal.innerHTML = `<div class="modal-box" style="max-width:440px">
-    <button class="modal-close-x" onclick="closeModal()">✕</button>
+    <button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>
     <div class="modal-title" style="margin-bottom:8px">Game summary</div>
     <div id="hist-export-box" style="background:#ebebe5;border:0.5px solid rgba(0,0,0,0.35);border-radius:var(--radius);padding:.85rem;font-size:11px;line-height:1.7;white-space:pre-wrap;word-break:break-word;margin-bottom:10px;color:#111110;max-height:320px;overflow-y:auto;font-family:'SF Mono',Menlo,monospace">${txt}</div>
     <div style="display:flex;gap:7px">
@@ -1349,7 +1349,7 @@ function showConfigForm(id) {
     </div>`).join('');
 
   modal.innerHTML = `<div class="modal-box">
-    <button class="modal-close-x" onclick="closeModal()">✕</button>
+    <button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>
     <div class="modal-title" style="margin-bottom:10px">${existing ? 'Edit' : 'New'} configuration</div>
     <div style="margin-bottom:10px"><div class="lbl">Name</div><input type="text" id="cfg-name" value="${existing ? existing.name : ''}" placeholder="e.g. EDHLL Minors 8"></div>
     <div class="row2" style="margin-bottom:14px">
@@ -1472,7 +1472,7 @@ function exportAllGames() {
   const modal = document.createElement('div'); modal.className = 'modal-overlay'; modal.id = 'active-modal';
   modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
   modal.innerHTML = `<div class="modal-box" style="max-width:420px">
-    <button class="modal-close-x" onclick="closeModal()">✕</button>
+    <button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>
     <div class="modal-title" style="margin-bottom:6px">Export game history</div>
     <div style="font-size:13px;color:#4a4945;margin-bottom:10px">${allGames.length} game${allGames.length > 1 ? 's' : ''} · CSV format. Copy and paste into Notes or email.</div>
     <textarea id="export-csv-box" style="font-family:'SF Mono',Menlo,monospace;font-size:10px;height:200px;resize:none;background:#ebebe5;border-color:rgba(0,0,0,0.25)">${csv}</textarea>
@@ -1508,7 +1508,7 @@ function importGames() {
   const modal = document.createElement('div'); modal.className = 'modal-overlay'; modal.id = 'active-modal';
   modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
   modal.innerHTML = `<div class="modal-box" style="max-width:420px">
-    <button class="modal-close-x" onclick="closeModal()">✕</button>
+    <button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg></button>
     <div class="modal-title" style="margin-bottom:6px">Import games</div>
     <div style="font-size:13px;color:#4a4945;margin-bottom:10px;line-height:1.5">Paste the CSV exported from this app. Existing games with the same date and teams will be skipped.</div>
     <textarea id="import-csv-input" placeholder="Paste CSV here..." style="height:180px;resize:none;font-family:'SF Mono',Menlo,monospace;font-size:11px"></textarea>


### PR DESCRIPTION
## Summary

- Replaces CSS-drawn hamburger bars (`<span>`) with SVG 3-line menu icon
- Replaces Unicode `✕` modal close buttons with SVG xmark icons
- Replaces `←` / `→` text arrows with SVG chevron-left/right icons
- Replaces `!` / `i` text alert indicators with SVG exclamation/info stroke icons
- All SVGs use `currentColor` for automatic color inheritance
- Simplified `.hbg-btn` CSS (removed span-specific styles)

## Test plan

- [ ] Verify hamburger menu icon renders correctly on game screen and history screen
- [ ] Verify all modal close buttons show xmark SVG (test: edit pitcher, edit catcher, config form, stats, confirm dialogs)
- [ ] Verify back buttons on summary, export, and config screens show chevron-left
- [ ] Verify "End half" and "Next batter" buttons show chevron-right
- [ ] Verify pitch alerts (warning, danger, info, critical) show SVG indicators
- [ ] Verify icons inherit correct colors in all states (active, danger, disabled)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)