### PR TITLE
Fix game screen visual and alert bugs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -129,21 +129,21 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 
 /* ── Simple mode ── */
 .hero-card{
-  background:var(--card);border-radius:20px;padding:18px 16px 16px;
-  margin-bottom:12px;text-align:center;
+  background:var(--card);border-radius:20px;padding:14px 16px 12px;
+  margin-bottom:10px;text-align:center;
   box-shadow:0 1px 0 rgba(0,0,0,.05);
 }
-.hero-at-bat-row{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
+.hero-at-bat-row{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
 .hero-at-bat-lbl{font-size:12px;font-weight:600;color:var(--t2);text-transform:uppercase;letter-spacing:.5px}
 .hero-at-bat-num{font-size:20px;font-weight:800;letter-spacing:-.5px;transition:color .2s}
-.hero-sep{width:100%;height:1px;background:var(--sep);margin-bottom:14px}
+.hero-sep{width:100%;height:1px;background:var(--sep);margin-bottom:10px}
 .hero-num{
-  font-size:88px;font-weight:900;line-height:1;letter-spacing:-4px;
+  font-size:64px;font-weight:900;line-height:1;letter-spacing:-3px;
   transition:transform .22s cubic-bezier(.36,1.6,.5,1),color .3s;
 }
-.hero-of{font-size:13px;color:var(--t2);margin-top:4px}
-.hero-rest{font-size:13px;font-weight:700;margin-top:6px}
-.pitch-dots{display:flex;gap:3px;flex-wrap:wrap;justify-content:center;margin-top:14px}
+.hero-of{font-size:13px;color:var(--t2);margin-top:3px}
+.hero-rest{font-size:13px;font-weight:700;margin-top:4px}
+.pitch-dots{display:flex;gap:3px;flex-wrap:wrap;justify-content:center;margin-top:10px}
 .pitch-dot{width:6px;height:6px;border-radius:3px;background:rgba(0,0,0,.12)}
 
 /* ── Advanced mode ── */
@@ -628,7 +628,7 @@ textarea{resize:vertical;min-height:56px}
       <div class="btn-sm" id="p-change-btn" onclick="togglePSelect()">Change</div>
     </div>
     <div id="pitcher-select-list" style="display:none"></div>
-    <div id="simple-alerts" style="display:none;min-height:48px"></div>
+    <div id="simple-alerts" style="display:none"></div>
 
     <!-- Advanced mode content -->
     <div id="adv-content" style="display:none">
@@ -1318,11 +1318,12 @@ function renderPitcherSection(){
   const psl=document.getElementById('pitcher-select-list');
   if(g.pSelectOpen){
     psl.style.display='block';
-    let h=roster.pitchers.map((p,i)=>{
+    let h='<div class="player-picker">';
+    h+=roster.pitchers.map((p,i)=>{
       const isA=i===idx;const ri2=restInfo(p.pitches);
       return`<div class="player-row" onclick="selectPitcher(${i})"><div class="player-radio" style="background:${isA?'var(--blue)':'transparent'};border:2px solid ${isA?'var(--blue)':'var(--sep2)'}"></div><div class="player-info"><div class="player-info-name">${p.name}${p.num?' <span class="player-info-num">#'+p.num+'</span>':''}</div><div class="player-info-sub">${p.pitches} pitches${ri2?` · ${ri2.label}`:''}</div></div>${isA?'<div class="badge-active">Active</div>':''}</div>`;
     }).join('');
-    h+=`<div class="add-player-form"><input type="text" id="new-p-name" placeholder="New pitcher name"><input type="text" id="new-p-num" class="num-input" placeholder="#"><div class="btn-sm" style="background:var(--blue);color:#fff;border-radius:10px;white-space:nowrap" onclick="addNewPitcherMidGame()">Add</div></div>`;
+    h+=`<div class="add-player-form"><input type="text" id="new-p-name" placeholder="New pitcher name" autocapitalize="words"><input type="text" id="new-p-num" class="num-input" placeholder="#"><div class="btn-sm" style="background:var(--blue);color:#fff;border-radius:10px;white-space:nowrap" onclick="addNewPitcherMidGame()">Add</div></div></div>`;
     psl.innerHTML=h;
   }else psl.style.display='none';
 }
@@ -1354,7 +1355,6 @@ function renderCatcherSection(){
     const pipColor=maxed?'var(--red)':warn?'var(--amber)':'var(--blue)';
     const pips=Array.from({length:C_INN_LIM}).map((_,i)=>`<div class="inn-pip ${i<inn?(maxed?'danger':warn?'warn':'filled'):''}"></div>`).join('');
     h+=`<div class="catcher-card ${maxed?'maxed':warn?'warn':''}"><div><div style="font-size:12px;color:${maxed?'var(--red)':'var(--t2)'};font-weight:500">${maxed?'Inning limit reached':`${left} inning${left!==1?'s':''} remaining`}</div><div class="inn-pips" style="margin-top:7px">${pips}</div></div><div style="text-align:right"><div class="catcher-count-num" style="color:${maxed?'var(--red)':warn?'var(--amber)':'var(--text)'}">${inn}</div><div style="font-size:11px;color:var(--t2);font-weight:600">of ${C_INN_LIM} inn.</div></div></div>`;
-    if(ap&&ap.pitches>=PITCH_C_LIM)h+=`<div class="alert a-warn"><div class="alert-dot"></div><span>Active pitcher threw ${ap.pitches}+ pitches — ineligible to catch remainder of day.</span></div>`;
     if(warn&&!maxed)h+=`<div class="alert a-warn"><div class="alert-dot"></div><span>${cat.name} is in their last allowed inning (${C_INN_LIM} inn. max).</span></div>`;
     if(maxed)h+=`<div class="alert a-danger"><div class="alert-dot"></div><span>${cat.name} has reached the ${C_INN_LIM}-inning catcher limit. Change catcher.</span></div>`;
   }else{h+=`<div style="font-size:13px;color:var(--t2);padding:6px 0">No catcher added.</div>`;}

--- a/tests/pitcher-catcher.spec.ts
+++ b/tests/pitcher-catcher.spec.ts
@@ -128,4 +128,11 @@ test.describe('Pitcher and catcher management', () => {
     await expect(catcherSection).toContainText('3 innings remaining');
     await expect(catcherSection).toContainText('of 4 inn.');
   });
+
+  test('change pitcher picker uses player-picker card style', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await page.click('#p-change-btn');
+    await page.waitForSelector('#pitcher-select-list[style*="block"]');
+    await expect(page.locator('#pitcher-select-list .player-picker')).toBeVisible();
+  });
 });

--- a/tests/thresholds-alerts.spec.ts
+++ b/tests/thresholds-alerts.spec.ts
@@ -77,8 +77,15 @@ test.describe('Thresholds and alerts', () => {
     await startGame(page, { mode: 'simple', homeCatcher: 'Mike C.' });
     await addSimplePitches(page, 41);
 
-    const catcherSection = page.locator('#catcher-section');
-    await expect(catcherSection).toContainText('ineligible to catch');
+    await expect(page.locator('#simple-alerts')).toContainText('cannot catch remainder');
+  });
+
+  test('pitcher cant catch alert does not appear in catcher section', async ({ page }) => {
+    await startGame(page, { mode: 'simple', homeCatcher: 'Mike C.' });
+    await addSimplePitches(page, 41);
+
+    await expect(page.locator('#catcher-section')).not.toContainText('ineligible');
+    await expect(page.locator('#catcher-section')).not.toContainText('pitcher');
   });
 
   test('at-bat warning shows at 6+ pitches in simple mode', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Compacted simple mode hero card to match advanced mode's default vertical footprint — reduced hero number font from 88px to 64px, tightened padding/margins, removed reserved min-height on alerts area so catcher section and button hints stay visible
- Removed misplaced pitcher eligibility alert ("ineligible to catch") from the catcher section — this warning now only appears in the pitcher alerts area where it belongs
- Wrapped pitcher picker list in `.player-picker` card class to match the catcher picker's white background styling (was rendering on gray)
- Mercy rule: verified code logic and all 8 existing tests pass; alert correctly triggers at configured run limit in both simple and advanced modes. Needs on-device verification to reproduce the reported scenario — may be config-specific

## Test plan
- [x] 3 new E2E tests added (93 total, all passing)
- [ ] Verify simple mode default view (no alerts) matches advanced mode vertical spacing
- [ ] Verify pitcher alerts expand properly when thresholds are hit
- [ ] Verify catcher section no longer shows pitcher eligibility warning at 41+ pitches
- [ ] Verify Change Pitcher and Change Catcher both show white card backgrounds
- [ ] On-device test: start game with 5-run mercy config, increment opposing score to 6, verify mercy alert triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)