### PR TITLE
Fix volume button capture and remove action button

### DIFF
--- a/app/ViewController.swift
+++ b/app/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, WKSc
     // Volume button tracking
     private var prevVolume: Float = 0.5
     private var volumeKVOActive = false
+    private weak var systemVolumeSlider: UISlider?
     // Debounce: ignore rapid repeat presses within 0.25s
     private var lastVolumeFire: TimeInterval = 0
     private let volumeDebounce: TimeInterval = 0.25
@@ -72,6 +73,7 @@ class ViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, WKSc
         // Activate audio session so we can observe outputVolume
         let session = AVAudioSession.sharedInstance()
         do {
+            try session.setCategory(.ambient, options: .mixWithOthers)
             try session.setActive(true)
         } catch {
             print("AVAudioSession activate error: \(error)")
@@ -83,12 +85,11 @@ class ViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, WKSc
                             context: nil)
         volumeKVOActive = true
 
-        // Add an invisible MPVolumeView — this suppresses the system volume HUD
-        // so the volume overlay doesn't appear when the user presses the buttons.
         let volumeView = MPVolumeView(frame: CGRect(x: -100, y: -100, width: 1, height: 1))
         volumeView.alpha = 0.001
         volumeView.isUserInteractionEnabled = false
         view.addSubview(volumeView)
+        systemVolumeSlider = volumeView.subviews.first(where: { $0 is UISlider }) as? UISlider
     }
 
     override func observeValue(forKeyPath keyPath: String?,
@@ -115,11 +116,8 @@ class ViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, WKSc
         }
         prevVolume = newVol
 
-        // Reset volume toward center (0.5) so there's room for future presses
-        // without hitting the system min/max.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            let slider = MPVolumeView.volumeSlider()
-            slider?.value = 0.5
+            self.systemVolumeSlider?.value = 0.5
             self.prevVolume = 0.5
         }
     }
@@ -255,11 +253,3 @@ class ViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, WKSc
     }
 }
 
-// MARK: - MPVolumeView helper (access hidden slider)
-
-private extension MPVolumeView {
-    static func volumeSlider() -> UISlider? {
-        let v = MPVolumeView(frame: .zero)
-        return v.subviews.first(where: { $0 is UISlider }) as? UISlider
-    }
-}

--- a/app/index.html
+++ b/app/index.html
@@ -797,12 +797,7 @@ function haptic(t){try{window.webkit?.messageHandlers?.haptic?.postMessage(t||'m
 const BTN_DEFAULTS_SIMPLE = { volUp:'pitch', volDown:'undo', action:'nextBatter' };
 const BTN_DEFAULTS_ADVANCED = { volUp:'nextBatter', volDown:'undo', action:'recordOut' };
 let btnMapping = { ...BTN_DEFAULTS_SIMPLE };
-function hasActionButton(){
-  const ua=navigator.userAgent;
-  if(!/iPhone/.test(ua))return false;
-  const m=ua.match(/iPhone\s*OS\s*(\d+)/);
-  return m&&parseInt(m[1])>=17;
-}
+function hasActionButton(){return false;}
 function applyModeDefaults(){
   const g=state.currentGame;if(!g)return;
   const defs=g.mode==='advanced'?BTN_DEFAULTS_ADVANCED:BTN_DEFAULTS_SIMPLE;


### PR DESCRIPTION
## Summary
- Fix volume button reset creating a new MPVolumeView instead of using the one in the view hierarchy, causing system volume to leak through during gameplay
- Set audio session category to `.ambient` with `.mixWithOthers` to avoid interrupting other audio
- Remove Action Button (iPhone 15 Pro+) from button mapping UI — no public API exists to capture it in a custom app

## Items addressed
- #10: Volume buttons changing device volume during use
- #13: Action button not working on iPhone 15 Pro+

## Test plan
- [x] Full suite passes: 91 tests green
- [ ] Verify on iOS device that volume buttons no longer change system volume
- [ ] Verify button mapping modal no longer shows Action Button row

🤖 Generated with [Claude Code](https://claude.com/claude-code)