### PR TITLE
Fix summary back navigation, radio buttons, and export tagline

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -19,6 +19,7 @@
 html,body{height:100%;background:var(--bg);overscroll-behavior:none;color-scheme:light only}
 body{font-family:var(--font);color:var(--text);-webkit-font-smoothing:antialiased}
 button,input,select,textarea{font-family:var(--font);-webkit-appearance:none;appearance:none}
+input[type="radio"]{-webkit-appearance:radio;appearance:radio}
 button{touch-action:manipulation;-webkit-user-select:none;user-select:none;cursor:pointer;border:none;background:transparent}
 .screen{display:none}.screen.active{display:block}
 
@@ -584,7 +585,7 @@ textarea{resize:vertical;min-height:56px}
           <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
           <div class="hbg-menu" id="game-hbg-menu">
             <button class="hbg-item" onclick="closeGameMenu();showStatsQuick()">Quick stats</button>
-            <button class="hbg-item" onclick="closeGameMenu();showScreen('summary')">Game summary</button>
+            <button class="hbg-item" onclick="closeGameMenu();state._expGame=null;state._expGameIdx=null;showScreen('summary')">Game summary</button>
             <button class="hbg-item" onclick="closeGameMenu();showButtonMappingModal()">Button mapping</button>
             <button class="hbg-item" onclick="closeGameMenu();closeGameToHistory()">Close</button>
             <div style="border-top:0.5px solid var(--sep);margin:5px 0"></div>
@@ -1947,7 +1948,7 @@ function buildSummaryText(){
   txt+=`\n\nHome Runs\n${'─'.repeat(30)}\n${g.homeTeam}: ${g.hrHome||'None'}\n${g.awayTeam}: ${g.hrAway||'None'}`;
   txt+=`\n\nUmpires\n${'─'.repeat(30)}\nPlate: ${g.umpPlateName||'—'} (Issues: ${g.umpPlateIssue||'No'})${g.umpPlateComments?' — '+g.umpPlateComments:''}`;
   txt+=`\nBase: ${g.umpBaseName||'—'} (Issues: ${g.umpBaseIssue||'No'})${g.umpBaseComments?' — '+g.umpBaseComments:''}`;
-  txt+=`\n\n—\nGenerated with Simple Pitch Counter\nhttps://apps.apple.com/us/app/simple-pitch-counter/id6760922314`;
+  txt+=`\n\n—\nGenerated with Simple Pitch Counter\nsimplepitchcounter.com`;
   return txt;
 }
 function copyExportModal(btn){

--- a/tests/summary-export.spec.ts
+++ b/tests/summary-export.spec.ts
@@ -223,4 +223,50 @@ test.describe('Game summary and export', () => {
     await page.locator('#screen-summary .btn-sm').filter({ hasText: 'Back' }).click();
     await expect(page.locator('#screen-history')).toHaveClass(/active/);
   });
+
+  test('mid-game summary back returns to game after viewing history', async ({ page }) => {
+    // Regression: if _expGame was set from a prior history view, mid-game
+    // summary Back would exit to history instead of returning to game.
+    await startGame(page, { mode: 'simple', homeTeam: 'Tigers', awayTeam: 'Lions' });
+    await addSimplePitches(page, 5);
+
+    await page.click('.menu-btn');
+    await page.click('text=Game summary');
+    await expect(page.locator('#screen-summary')).toHaveClass(/active/);
+
+    await page.locator('#screen-summary .btn-sm').filter({ hasText: 'Back' }).click();
+    await expect(page.locator('#screen-game')).toHaveClass(/active/);
+  });
+
+  test('umpire radio buttons render as radio inputs', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await page.click('.menu-btn');
+    await page.click('text=Game summary');
+
+    const radios = page.locator('input[type="radio"][name="pu-iss"]');
+    await expect(radios).toHaveCount(2);
+    const firstRadio = radios.first();
+    const appearance = await firstRadio.evaluate(el => {
+      const style = window.getComputedStyle(el);
+      return style.appearance || style.webkitAppearance;
+    });
+    expect(appearance).toBe('radio');
+  });
+
+  test('export tagline uses website URL not app store', async ({ page }) => {
+    await startGame(page, { mode: 'simple', homeTeam: 'Tigers', awayTeam: 'Lions' });
+    await addSimplePitches(page, 5);
+
+    await page.click('.menu-btn');
+    await page.click('text=End game');
+    await page.click('.modal-btn.red');
+
+    await page.click('text=Edit summary');
+    await page.click('text=Share');
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+
+    const modalText = await page.locator('.modal-box').textContent();
+    expect(modalText).toContain('simplepitchcounter.com');
+    expect(modalText).not.toContain('apps.apple.com');
+  });
 });


### PR DESCRIPTION
## Summary
- Fix mid-game summary Back button exiting to history instead of returning to game (stale `_expGame` reference)
- Restore umpire radio button icons hidden by global `appearance:none` CSS reset
- Replace raw App Store URL in export tagline with `simplepitchcounter.com`

## Items addressed
- #1: Mid-game summary Back exits to history
- #2: Umpire radio button icons not rendering
- #5: Export tagline URL cleanup

## Test plan
- [x] 3 new E2E tests added (19 total in summary-export)
- [x] Full summary test suite passes
- [ ] Verify radio buttons render on iOS device

🤖 Generated with [Claude Code](https://claude.com/claude-code)