### PR TITLE
Fix stats drawer UX: swipe dismiss and image share

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -278,6 +278,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
   background:var(--dark);border-radius:24px 24px 0 0;
   padding:20px 20px 40px;
   width:100%;max-width:430px;max-height:85vh;overflow-y:auto;
+  transition:transform .2s ease-out;
 }
 .stats-handle{width:36px;height:4px;border-radius:2px;background:rgba(255,255,255,.2);margin:0 auto 18px}
 .stats-summary-row{display:flex;gap:8px;margin-bottom:18px}
@@ -1395,6 +1396,33 @@ function renderBtnHints(){
   el.innerHTML=chips?`<div class="btn-hints">${chips}</div>`:'';
 }
 
+// ── Swipe-to-dismiss for bottom sheets ──
+function enableSwipeDismiss(overlay){
+  const sheet=overlay.querySelector('.stats-sheet');if(!sheet)return;
+  let startY=0,currentY=0,dragging=false;
+  const onStart=e=>{
+    const t=e.touches?e.touches[0]:e;startY=t.clientY;currentY=0;dragging=true;
+    sheet.style.transition='none';
+  };
+  const onMove=e=>{
+    if(!dragging)return;const t=e.touches?e.touches[0]:e;
+    currentY=Math.max(0,t.clientY-startY);
+    sheet.style.transform=`translateY(${currentY}px)`;
+  };
+  const onEnd=()=>{
+    if(!dragging)return;dragging=false;
+    sheet.style.transition='transform .2s ease-out';
+    if(currentY>80){sheet.style.transform='translateY(100%)';setTimeout(()=>overlay.remove(),200);}
+    else sheet.style.transform='';
+  };
+  sheet.addEventListener('touchstart',onStart,{passive:true});
+  sheet.addEventListener('touchmove',onMove,{passive:true});
+  sheet.addEventListener('touchend',onEnd);
+  sheet.addEventListener('mousedown',onStart);
+  sheet.addEventListener('mousemove',onMove);
+  sheet.addEventListener('mouseup',onEnd);
+}
+
 // ── Pitcher stats ──
 function pitcherDerivedStats(p){
   const ip=p.innings?.filter(Boolean).length||0;
@@ -1553,7 +1581,7 @@ function showPitcherStats(){
     </div>
   </div>`;
   window._sharedPitcher=ap;
-  el.appendChild(ov);
+  el.appendChild(ov);enableSwipeDismiss(ov);
 }
 
 // ── Button mapping modal ──
@@ -1710,7 +1738,7 @@ function showStatsQuick(){
       <div onclick="document.getElementById('stats-sheet-overlay').remove()" style="flex:1;height:50px;border-radius:14px;background:rgba(255,255,255,.1);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;font-weight:600;color:#fff">Close</div>
     </div>
   </div>`;
-  el.appendChild(ov);
+  el.appendChild(ov);enableSwipeDismiss(ov);
 }
 
 // ── Modal helpers ──
@@ -1897,7 +1925,7 @@ function showSummaryStats(side,idx){
   ov.addEventListener('click',e=>{if(e.target===ov)ov.remove();});
   let barsHtml=types.map(k=>{const pt=PT_TYPES[k];const v=(p.pitchTypes||{})[k]||0;const pct=denom?Math.round(v/denom*100):0;return`<div class="stats-bar-row"><div class="stats-bar-chip" style="background:${pt.bg};color:${pt.color}">${pt.label}</div><div class="stats-bar"><div class="stats-bar-fill" style="background:${pt.color};width:${pct}%"></div></div><div class="stats-bar-count">${v}</div><div class="stats-bar-pct">${pct}%</div></div>`;}).join('');
   ov.innerHTML=`<div class="stats-sheet"><div class="stats-handle"></div><div style="font-size:17px;font-weight:700;color:#fff;margin-bottom:4px">${p.name}${p.num?' #'+p.num:''}</div><div style="font-size:13px;color:var(--dark-label);margin-bottom:18px">${total} total pitches</div><div class="stats-summary-row"><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--red)">${p.ks||0}</div><div class="stats-summary-lbl">K</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--blue)">${p.bbs||0}</div><div class="stats-summary-lbl">BB</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--green)">${p.bips||0}</div><div class="stats-summary-lbl">BIP</div></div></div><div style="font-size:11px;font-weight:700;color:rgba(235,235,245,.45);text-transform:uppercase;letter-spacing:.7px;margin-bottom:10px">Pitch Breakdown</div>${barsHtml}<div onclick="document.getElementById('sum-stats-overlay').remove()" style="margin-top:16px;width:100%;height:50px;border-radius:14px;background:rgba(255,255,255,.1);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;font-weight:600;color:#fff">Close</div></div>`;
-  document.getElementById('screen-summary').appendChild(ov);
+  document.getElementById('screen-summary').appendChild(ov);enableSwipeDismiss(ov);
 }
 function saveSummaryAndBack(){
   collectSummaryData();saveState();
@@ -1967,8 +1995,9 @@ function openSavedStats(gi){
   const ov=document.createElement('div');ov.className='stats-sheet-overlay';ov.id='saved-stats-overlay';
   ov.addEventListener('click',e=>{if(e.target===ov)ov.remove();});
   const types=['B','CS','SS','F','BIP'];
-  let pidCounter=0;
+  let pidCounter=0;window._svPitchers=[];
   const mkPitcherRow=(p,team)=>{
+    const svIdx=window._svPitchers.length;window._svPitchers.push({p,g});
     const ri=restInfo(p.pitches);
     const restColor=!ri?'var(--green)':ri.days===0?'var(--green)':ri.days===1?'var(--amber)':'var(--red)';
     const restText=ri?ri.label:'No rest needed';
@@ -1979,11 +2008,10 @@ function openSavedStats(gi){
       const total=p.pitches||0;const denom=total||1;
       barsHtml=`<div style="font-size:11px;font-weight:700;color:rgba(235,235,245,.45);text-transform:uppercase;letter-spacing:.7px;margin:12px 0 10px">Pitch Breakdown</div>`+types.map(k=>{const pt=PT_TYPES[k];const v=(p.pitchTypes||{})[k]||0;const pct=denom?Math.round(v/denom*100):0;return`<div class="stats-bar-row"><div class="stats-bar-chip" style="background:${pt.bg};color:${pt.color}">${pt.label}</div><div class="stats-bar"><div class="stats-bar-fill" style="background:${pt.color};width:${pct}%"></div></div><div class="stats-bar-count">${v}</div><div class="stats-bar-pct">${pct}%</div></div>`;}).join('');
     }
-    const exportLine=`${p.name}${p.num?' #'+p.num:''} — ${p.pitches} pitches, ${s.ip} IP, ${s.bf} BF, K:${s.ks} BB:${s.bbs} K/BB:${s.kbb}${ri?' — '+ri.label:''}`;
     const detailHtml=`<div id="${pid}" style="display:none;margin-top:10px;padding-top:10px;border-top:1px solid rgba(255,255,255,.1)">
       ${statLineHtml(p)}
       ${barsHtml}
-      <div onclick="sharePitcherLine('${exportLine.replace(/'/g,"\\'")}')" style="margin-top:10px;width:100%;height:40px;border-radius:10px;background:rgba(255,255,255,.08);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:13px;font-weight:600;color:rgba(235,235,245,.6)">Share pitcher stats ↗</div>
+      <div onclick="shareStatsCard(window._svPitchers[${svIdx}].p,window._svPitchers[${svIdx}].g)" style="margin-top:10px;width:100%;height:40px;border-radius:10px;background:rgba(255,255,255,.08);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:13px;font-weight:600;color:rgba(235,235,245,.6)">Share pitcher stats ↗</div>
     </div>`;
     return`<div style="background:rgba(255,255,255,.06);border-radius:14px;padding:14px;margin-bottom:8px">
       <div onclick="const d=document.getElementById('${pid}');if(d)d.style.display=d.style.display==='none'?'block':'none'" style="cursor:pointer;display:flex;align-items:center;justify-content:space-between">
@@ -2014,7 +2042,7 @@ function openSavedStats(gi){
       <div onclick="document.getElementById('saved-stats-overlay').remove()" style="flex:1;height:50px;border-radius:14px;background:rgba(255,255,255,.1);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;font-weight:600;color:#fff">Close</div>
     </div>
   </div>`;
-  document.body.appendChild(ov);
+  document.body.appendChild(ov);enableSwipeDismiss(ov);
 }
 function sharePitcherLine(line){
   if(navigator.share){navigator.share({text:line}).catch(()=>{});}

--- a/docs/process/deployment.md
+++ b/docs/process/deployment.md
@@ -41,7 +41,7 @@ Follow conventional style:
 
 ### Automated E2E Tests
 
-91 Playwright tests run on every push and PR to `main` via GitHub Actions (`test.yml`).
+116 Playwright tests run on every push and PR to `main` via GitHub Actions (`test.yml`).
 
 **Test suites:**
 
@@ -52,6 +52,7 @@ Follow conventional style:
 | `thresholds-alerts.spec.ts` | 17 | Rest labels, limit alerts, catcher innings, mercy rule, at-bat warnings |
 | `pitcher-catcher.spec.ts` | 10 | Mid-game changes, count preservation, stats, half-inning switching |
 | `summary-export.spec.ts` | 11 | Summary screen, export text, umpire data, pitch breakdowns |
+| `shareable-stats.spec.ts` | 14 | Share features, swipe-to-dismiss, image card exports |
 | `history-config.spec.ts` | 12 | History cards, persistence, setup screen, mode toggle, umpire clearing |
 
 **Run locally:**

--- a/tests/shareable-stats.spec.ts
+++ b/tests/shareable-stats.spec.ts
@@ -143,7 +143,7 @@ test.describe('Shareable stats cards', () => {
     }
   });
 
-  test('individual pitcher share from history detail', async ({ page }) => {
+  test('individual pitcher share from history triggers image download', async ({ page }) => {
     await startGame(page, { mode: 'simple' });
     await addSimplePitches(page, 10);
 
@@ -155,11 +155,83 @@ test.describe('Shareable stats cards', () => {
     await page.click('text=Stats');
     await page.waitForSelector('#saved-stats-overlay .stats-sheet');
 
-    // Click a pitcher row to expand details
     const pitcherRow = page.locator('#saved-stats-overlay .stats-sheet').getByText('Jake M.');
     await pitcherRow.click();
-
-    // Expanded detail should have individual share link
     await expect(page.locator('#saved-stats-overlay')).toContainText('Share pitcher stats');
+
+    const downloadPromise = page.waitForEvent('download', { timeout: 5000 }).catch(() => null);
+    await page.locator('#saved-stats-overlay').getByText('Share pitcher stats').click();
+    const download = await downloadPromise;
+    expect(download).not.toBeNull();
+    if (download) {
+      expect(download.suggestedFilename()).toBe('pitcher-stats.png');
+    }
+  });
+
+  test('swipe down dismisses stats sheet overlay', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await addSimplePitches(page, 5);
+
+    await page.click('.menu-btn');
+    await page.click('text=Quick stats');
+    await page.waitForSelector('.stats-sheet');
+
+    const sheet = page.locator('.stats-sheet');
+    const box = await sheet.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 20);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 200, { steps: 10 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(300);
+    await expect(page.locator('.stats-sheet-overlay')).toHaveCount(0);
+  });
+
+  test('small swipe does not dismiss stats sheet', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await addSimplePitches(page, 5);
+
+    await page.click('.menu-btn');
+    await page.click('text=Quick stats');
+    await page.waitForSelector('.stats-sheet');
+
+    const sheet = page.locator('.stats-sheet');
+    const box = await sheet.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 20);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 50, { steps: 5 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(300);
+    await expect(page.locator('.stats-sheet-overlay')).toHaveCount(1);
+  });
+
+  test('history stats overlay supports swipe dismiss', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await addSimplePitches(page, 5);
+
+    await page.click('.menu-btn');
+    await page.click('text=End game');
+    await page.click('.modal-btn.red');
+    await expect(page.locator('#screen-history')).toHaveClass(/active/);
+
+    await page.click('text=Stats');
+    await page.waitForSelector('#saved-stats-overlay .stats-sheet');
+
+    const sheet = page.locator('#saved-stats-overlay .stats-sheet');
+    const box = await sheet.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 20);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 200, { steps: 10 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(300);
+    await expect(page.locator('#saved-stats-overlay')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
- All 4 stats sheet overlays now support swipe-down gesture to dismiss (touch events + mouse fallback)
- Individual pitcher share from history detail now exports as image card (via `shareStatsCard`) instead of plain text
- Added `enableSwipeDismiss()` to `openSavedStats()` (the 4th and final stats overlay)
- 4 new E2E tests: swipe dismiss, small swipe snap-back, history overlay swipe dismiss, individual pitcher image download

## Test plan
- [ ] Verify swipe-down dismisses all 4 stats sheet overlays (live pitcher stats, quick stats, summary stats, history stats)
- [ ] Verify small swipes snap the sheet back without dismissing
- [ ] Verify individual pitcher "Share pitcher stats" from history detail exports an image (PNG) not text
- [ ] All 116 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)