### PR TITLE
Remove taglines from About screen

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -803,7 +803,7 @@ textarea{resize:vertical;min-height:56px}
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">
-        A fast, focused pitch counting app for Little League coaches and parents. Track pitch counts, rest requirements, innings, and at-bats — all from your pocket. Built with love for the game.
+        A fast, focused pitch counting app for Little League coaches and parents. Track pitch counts, rest requirements, innings, and at-bats — all from your pocket.
       </div>
     </div>
     <div style="background:var(--card);border:1.5px solid var(--sep2);border-radius:var(--r-lg);overflow:hidden;margin-bottom:12px">
@@ -828,9 +828,6 @@ textarea{resize:vertical;min-height:56px}
       <div style="font-size:16px;font-weight:700;color:#000">☕ Buy Me a Coffee</div>
       <div style="font-size:13px;color:rgba(0,0,0,.6);margin-top:4px">Keep this app free and supported</div>
     </a>
-    <div style="text-align:center;font-size:12px;color:var(--t3);margin-top:20px">
-      Made with ❤️ for Little League
-    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Removed "Built with love for the game" from app description
- Removed "Made with ❤️ for Little League" footer tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)