### PR TITLE
Align stats drawers and rename Summary button

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1863,7 +1863,7 @@ function renderHistory(){
         </div>
         ${allRest.length?`<div class="rest-section"><div class="rest-section-lbl">Rest required</div>${allRest.map(r=>`<div class="rest-row"><div class="rest-name">${r.name}${r.num?' <span style="color:var(--t3)">#'+r.num+'</span>':''} <span class="rest-sub">· ${r.pitches} pitches</span></div><div class="rest-chip" style="background:${r.days>=2?'var(--red-bg)':'var(--amber-bg)'};color:${r.days>=2?'var(--red)':'var(--amber)'}">${r.days}d rest</div></div>`).join('')}</div>`:''}
         <div class="hist-card-actions">
-          ${live?`<div class="hist-action-btn primary" onclick="resumeGame(${gi})">Resume</div>`:`<div class="hist-action-btn secondary" onclick="openSavedStats(${gi})">View stats</div><div class="hist-action-btn secondary" onclick="openExportForGame(${gi})">Edit summary</div>`}
+          ${live?`<div class="hist-action-btn primary" onclick="resumeGame(${gi})">Resume</div>`:`<div class="hist-action-btn secondary" onclick="openSavedStats(${gi})">View stats</div><div class="hist-action-btn secondary" onclick="openExportForGame(${gi})">Summary</div>`}
         </div>
       </div>
     </div>`;

--- a/app/index.html
+++ b/app/index.html
@@ -1618,6 +1618,7 @@ function showPitcherStats(){
     <div style="font-size:17px;font-weight:700;color:#fff;margin-bottom:4px">${ap.name}${ap.num?' #'+ap.num:''}</div>
     <div style="font-size:13px;color:var(--dark-label);margin-bottom:4px">${total} total pitches · ${s.ip} innings</div>
     <div style="font-size:12px;font-weight:600;color:${restColor};margin-bottom:16px">${restText}</div>
+    <div class="stats-summary-row"><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--red)">${ap.ks||0}</div><div class="stats-summary-lbl">K</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--blue)">${ap.bbs||0}</div><div class="stats-summary-lbl">BB</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--green)">${ap.bips||0}</div><div class="stats-summary-lbl">BIP</div></div></div>
     ${statLineHtml(ap)}
     ${barsHtml}
     <div style="display:flex;gap:8px;margin-top:16px">
@@ -1963,13 +1964,30 @@ function initSummary(){
 function showSummaryStats(side,idx){
   const g=state.currentGame||state._expGame;if(!g)return;
   const p=g[side].pitchers[idx];if(!p)return;
-  // Use same stats sheet
   const types=['B','CS','SS','F','BIP'];const total=p.pitches||0;const denom=total||1;
+  const s=pitcherDerivedStats(p);
+  const ri=restInfo(p.pitches);
+  const restColor=!ri?'var(--green)':ri.days===0?'var(--green)':ri.days===1?'var(--amber)':'var(--red)';
+  const restText=ri?ri.label:'No pitches';
   const existing=document.getElementById('sum-stats-overlay');if(existing)existing.remove();
   const ov=document.createElement('div');ov.className='stats-sheet-overlay';ov.id='sum-stats-overlay';
   ov.addEventListener('click',e=>{if(e.target===ov)ov.remove();});
-  let barsHtml=types.map(k=>{const pt=PT_TYPES[k];const v=(p.pitchTypes||{})[k]||0;const pct=denom?Math.round(v/denom*100):0;return`<div class="stats-bar-row"><div class="stats-bar-chip" style="background:${pt.bg};color:${pt.color}">${pt.label}</div><div class="stats-bar"><div class="stats-bar-fill" style="background:${pt.color};width:${pct}%"></div></div><div class="stats-bar-count">${v}</div><div class="stats-bar-pct">${pct}%</div></div>`;}).join('');
-  ov.innerHTML=`<div class="stats-sheet"><div class="stats-handle"></div><div style="font-size:17px;font-weight:700;color:#fff;margin-bottom:4px">${p.name}${p.num?' #'+p.num:''}</div><div style="font-size:13px;color:var(--dark-label);margin-bottom:18px">${total} total pitches</div><div class="stats-summary-row"><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--red)">${p.ks||0}</div><div class="stats-summary-lbl">K</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--blue)">${p.bbs||0}</div><div class="stats-summary-lbl">BB</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--green)">${p.bips||0}</div><div class="stats-summary-lbl">BIP</div></div></div><div style="font-size:11px;font-weight:700;color:rgba(235,235,245,.45);text-transform:uppercase;letter-spacing:.7px;margin-bottom:10px">Pitch Breakdown</div>${barsHtml}<div onclick="document.getElementById('sum-stats-overlay').remove()" style="margin-top:16px;width:100%;height:50px;border-radius:14px;background:rgba(255,255,255,.1);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;font-weight:600;color:#fff">Close</div></div>`;
+  let barsHtml='';
+  if(g.mode==='advanced'){
+    barsHtml=`<div style="font-size:11px;font-weight:700;color:rgba(235,235,245,.45);text-transform:uppercase;letter-spacing:.7px;margin-bottom:10px">Pitch Breakdown</div>`+types.map(k=>{const pt=PT_TYPES[k];const v=(p.pitchTypes||{})[k]||0;const pct=denom?Math.round(v/denom*100):0;return`<div class="stats-bar-row"><div class="stats-bar-chip" style="background:${pt.bg};color:${pt.color}">${pt.label}</div><div class="stats-bar"><div class="stats-bar-fill" style="background:${pt.color};width:${pct}%"></div></div><div class="stats-bar-count">${v}</div><div class="stats-bar-pct">${pct}%</div></div>`;}).join('');
+  }
+  window._sumStatsPitcher=p;window._sumStatsGame=g;
+  ov.innerHTML=`<div class="stats-sheet"><div class="stats-handle"></div>
+    <div style="font-size:17px;font-weight:700;color:#fff;margin-bottom:4px">${p.name}${p.num?' #'+p.num:''}</div>
+    <div style="font-size:13px;color:var(--dark-label);margin-bottom:4px">${total} total pitches · ${s.ip} innings</div>
+    <div style="font-size:12px;font-weight:600;color:${restColor};margin-bottom:16px">${restText}</div>
+    <div class="stats-summary-row"><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--red)">${p.ks||0}</div><div class="stats-summary-lbl">K</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--blue)">${p.bbs||0}</div><div class="stats-summary-lbl">BB</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--green)">${p.bips||0}</div><div class="stats-summary-lbl">BIP</div></div></div>
+    ${statLineHtml(p)}
+    ${barsHtml}
+    <div style="display:flex;gap:8px;margin-top:16px">
+      <div onclick="shareStatsCard(window._sumStatsPitcher,window._sumStatsGame)" style="flex:1;height:50px;border-radius:14px;background:rgba(255,255,255,.1);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;font-weight:600;color:#fff">Share</div>
+      <div onclick="document.getElementById('sum-stats-overlay').remove()" style="flex:1;height:50px;border-radius:14px;background:rgba(255,255,255,.1);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;font-weight:600;color:#fff">Close</div>
+    </div></div>`;
   document.getElementById('screen-summary').appendChild(ov);enableSwipeDismiss(ov);
 }
 function saveSummaryAndBack(){
@@ -2054,6 +2072,7 @@ function openSavedStats(gi){
       barsHtml=`<div style="font-size:11px;font-weight:700;color:rgba(235,235,245,.45);text-transform:uppercase;letter-spacing:.7px;margin:12px 0 10px">Pitch Breakdown</div>`+types.map(k=>{const pt=PT_TYPES[k];const v=(p.pitchTypes||{})[k]||0;const pct=denom?Math.round(v/denom*100):0;return`<div class="stats-bar-row"><div class="stats-bar-chip" style="background:${pt.bg};color:${pt.color}">${pt.label}</div><div class="stats-bar"><div class="stats-bar-fill" style="background:${pt.color};width:${pct}%"></div></div><div class="stats-bar-count">${v}</div><div class="stats-bar-pct">${pct}%</div></div>`;}).join('');
     }
     const detailHtml=`<div id="${pid}" style="display:none;margin-top:10px;padding-top:10px;border-top:1px solid rgba(255,255,255,.1)">
+      <div class="stats-summary-row"><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--red)">${p.ks||0}</div><div class="stats-summary-lbl">K</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--blue)">${p.bbs||0}</div><div class="stats-summary-lbl">BB</div></div><div class="stats-summary-box"><div class="stats-summary-num" style="color:var(--green)">${p.bips||0}</div><div class="stats-summary-lbl">BIP</div></div></div>
       ${statLineHtml(p)}
       ${barsHtml}
       <div onclick="shareStatsCard(window._svPitchers[${svIdx}].p,window._svPitchers[${svIdx}].g)" style="margin-top:10px;width:100%;height:40px;border-radius:10px;background:rgba(255,255,255,.08);display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:13px;font-weight:600;color:rgba(235,235,245,.6)">Share pitcher stats ↗</div>

--- a/tests/summary-export.spec.ts
+++ b/tests/summary-export.spec.ts
@@ -78,7 +78,7 @@ test.describe('Game summary and export', () => {
     await page.click('.modal-btn.red');
     await expect(page.locator('#screen-history')).toHaveClass(/active/);
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await expect(page.locator('#screen-summary')).toHaveClass(/active/);
     await expect(page.locator('#sum-home-pitchers-wrap')).toContainText('Jake M.');
   });
@@ -91,7 +91,7 @@ test.describe('Game summary and export', () => {
     await page.click('text=End game');
     await page.click('.modal-btn.red');
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await expect(page.locator('#sum-actions')).toBeVisible();
     await expect(page.locator('#sum-actions')).toContainText('Save');
     await expect(page.locator('#sum-actions')).toContainText('Share');
@@ -105,14 +105,14 @@ test.describe('Game summary and export', () => {
     await page.click('text=End game');
     await page.click('.modal-btn.red');
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await page.fill('#sum-pu-name', 'John Doe');
     await page.click('text=Save');
 
     await page.locator('#screen-summary .btn-sm').filter({ hasText: 'Back' }).click();
     await expect(page.locator('#screen-history')).toHaveClass(/active/);
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await expect(page.locator('#sum-pu-name')).toHaveValue('John Doe');
   });
 
@@ -124,7 +124,7 @@ test.describe('Game summary and export', () => {
     await page.click('text=End game');
     await page.click('.modal-btn.red');
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await page.click('text=Share');
     await page.waitForSelector('.modal-overlay', { timeout: 3000 });
 
@@ -147,7 +147,7 @@ test.describe('Game summary and export', () => {
     await page.click('.modal-btn.red');
     await expect(page.locator('#screen-history')).toHaveClass(/active/);
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await page.click('text=Share');
     await page.waitForSelector('.modal-overlay', { timeout: 3000 });
 
@@ -165,7 +165,7 @@ test.describe('Game summary and export', () => {
     await page.click('.modal-btn.red');
     await expect(page.locator('#screen-history')).toHaveClass(/active/);
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await page.click('text=Share');
     await page.waitForSelector('.modal-overlay', { timeout: 3000 });
 
@@ -217,7 +217,7 @@ test.describe('Game summary and export', () => {
     await page.click('.modal-btn.red');
     await expect(page.locator('#screen-history')).toHaveClass(/active/);
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await expect(page.locator('#screen-summary')).toHaveClass(/active/);
 
     await page.locator('#screen-summary .btn-sm').filter({ hasText: 'Back' }).click();
@@ -261,7 +261,7 @@ test.describe('Game summary and export', () => {
     await page.click('text=End game');
     await page.click('.modal-btn.red');
 
-    await page.click('text=Edit summary');
+    await page.click('text=Summary');
     await page.click('text=Share');
     await page.waitForSelector('.modal-overlay', { timeout: 3000 });
 


### PR DESCRIPTION
## Summary
- Added K/BB/BIP summary boxes to live game pitcher stats drawer and history detail view
- Updated game summary stats drawer to include full stat lines, rest info, and Share button (matching other drawers)
- Pitch breakdown bars now only show in advanced mode consistently across all drawers
- Renamed history card button from "Edit summary" to "Summary"

## Test plan
- [ ] Verify K/BB/BIP summary boxes appear in all pitcher stats drawers
- [ ] Verify game summary pitcher stats drawer now has Share button and full stat lines
- [ ] Verify pitch breakdown only shows in advanced mode across all drawers
- [ ] Verify history card button reads "Summary"
- [ ] All 129 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)