### PR TITLE
Add v2.2 tests and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Simple Pitch Counter tracks pitch counts and catcher innings during live games, 
 - **Mercy rule auto-prompt** — when runs scored in a half inning reach the configured mercy limit, a modal prompts to end the half or continue playing; tracks runs from either team
 - **Advanced pitch tracking** — tracks balls, strikes, and outs automatically; records pitch-by-pitch sequences per at-bat with visual chips; auto-advances count on walks, strikeouts, and balls in play
 - **Ball in play outcomes** — when a ball is put in play, a bottom sheet prompts for Safe/Out with automatic out tracking and side-retired detection
+- **Shareable stats cards** — generate and share pitcher stats as image cards (PNG) with K/BB/BIP hero boxes, pitch breakdowns, and rest info; works from live game, game summary, and history views
 - **Live pitcher stats** — dark-themed bottom sheet showing K, BB, BIP totals and a full pitch type breakdown with percentage bars
 - **Configurable league rules** — set pitch limits, rest-day thresholds, and catcher inning rules per division (e.g., Minors 8, Minors 9/10, Majors)
 - **Threshold awareness** — alerts when a pitcher approaches or crosses a rest-day threshold, with support for the "finish the batter" rule
@@ -38,6 +39,8 @@ Simple Pitch Counter tracks pitch counts and catcher innings during live games, 
 - **Result flash animations** — full-screen animated overlays for strikeouts, walks, outs, safe calls, and side retired
 - **Data export/import** — export all game data as JSON (via Share Sheet on iOS) and import backups from the history menu
 - **Pitch dot visualization** — dots below the hero count alternate shading per batter to show at-bat boundaries at a glance
+- **Swipe-to-dismiss stats** — swipe down on any stats bottom sheet to dismiss it
+- **About screen** — accessible from the history menu; shows app version, links to website, privacy policy, feedback form, and Buy Me a Coffee
 - **Fully offline** — no account, no internet, no ads. All data stays on your device via localStorage
 
 ### Game summary output
@@ -69,7 +72,9 @@ simple-pitch-counter/
 │   ├── thresholds-alerts.spec.ts   # Rest days, pitch limits, mercy rule
 │   ├── pitcher-catcher.spec.ts     # Roster management, mid-game switches
 │   ├── summary-export.spec.ts      # Game summary, report generation, export
-│   └── history-config.spec.ts      # History cards, config presets, setup flow
+│   ├── shareable-stats.spec.ts     # Share features, swipe-to-dismiss, image cards
+│   ├── history-config.spec.ts      # History cards, config presets, setup flow
+│   └── about-screen.spec.ts        # About screen, links, back navigation
 ├── .github/workflows/      # CI/CD
 │   └── test.yml            # Runs Playwright tests on push/PR to main
 ├── website/                # simplepitchcounter.com
@@ -90,16 +95,18 @@ simple-pitch-counter/
 
 ## Testing
 
-The project has **91 Playwright E2E tests** covering all app functionality:
+The project has **134 Playwright E2E tests** covering all app functionality:
 
 | Spec file | Tests | Coverage |
 |-----------|-------|----------|
 | `core-game-flow` | 20 | Game lifecycle, scoring, outs (both modes), undo, persistence |
 | `advanced-mode` | 21 | Pitch types, BSO count, BIP modal, auto-advance, non-pitch outs |
-| `thresholds-alerts` | 17 | Rest days, pitch limits, mercy rule modal, at-bat warnings |
-| `pitcher-catcher` | 10 | Roster management, mid-game switches, inning tracking |
-| `summary-export` | 11 | Game summary, umpire data, report generation, export |
-| `history-config` | 12 | History cards, config presets, setup flow, umpire clearing |
+| `thresholds-alerts` | 18 | Rest days, pitch limits, mercy rule modal, at-bat warnings |
+| `pitcher-catcher` | 11 | Roster management, mid-game switches, inning tracking |
+| `summary-export` | 19 | Game summary, umpire data, report generation, export |
+| `shareable-stats` | 18 | Share features, swipe-to-dismiss, image card exports, K/BB/BIP boxes |
+| `history-config` | 19 | History cards, config presets, setup flow, umpire clearing |
+| `about-screen` | 8 | About screen, app info, links, back navigation |
 
 ```bash
 npm test              # Run all tests (headless)

--- a/docs/process/deployment.md
+++ b/docs/process/deployment.md
@@ -41,7 +41,7 @@ Follow conventional style:
 
 ### Automated E2E Tests
 
-116 Playwright tests run on every push and PR to `main` via GitHub Actions (`test.yml`).
+134 Playwright tests run on every push and PR to `main` via GitHub Actions (`test.yml`).
 
 **Test suites:**
 
@@ -49,11 +49,12 @@ Follow conventional style:
 |------|-------|----------|
 | `core-game-flow.spec.ts` | 20 | Game lifecycle, scoring, outs (both modes), undo, persistence |
 | `advanced-mode.spec.ts` | 21 | Pitch types, B/S/F counting, walks, strikeouts, BIP, auto-outs |
-| `thresholds-alerts.spec.ts` | 17 | Rest labels, limit alerts, catcher innings, mercy rule, at-bat warnings |
-| `pitcher-catcher.spec.ts` | 10 | Mid-game changes, count preservation, stats, half-inning switching |
-| `summary-export.spec.ts` | 11 | Summary screen, export text, umpire data, pitch breakdowns |
-| `shareable-stats.spec.ts` | 14 | Share features, swipe-to-dismiss, image card exports |
-| `history-config.spec.ts` | 12 | History cards, persistence, setup screen, mode toggle, umpire clearing |
+| `thresholds-alerts.spec.ts` | 18 | Rest labels, limit alerts, catcher innings, mercy rule, at-bat warnings |
+| `pitcher-catcher.spec.ts` | 11 | Mid-game changes, count preservation, stats, half-inning switching |
+| `summary-export.spec.ts` | 19 | Summary screen, export text, umpire data, pitch breakdowns |
+| `shareable-stats.spec.ts` | 18 | Share features, swipe-to-dismiss, image card exports, K/BB/BIP boxes |
+| `history-config.spec.ts` | 19 | History cards, persistence, setup screen, mode toggle, umpire clearing |
+| `about-screen.spec.ts` | 8 | About screen, app info, links, back navigation |
 
 **Run locally:**
 ```bash

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -1,6 +1,6 @@
 # Technical Documentation: Simple Pitch Counter
 
-**Last updated:** 2026-03-26
+**Last updated:** 2026-04-21
 
 ---
 
@@ -158,7 +158,7 @@ The entire UI lives in a single `index.html` file, structured as:
 
 ### HTML Screens (lines 200-440)
 
-Six screen divs, toggled via `.active` class:
+Seven screen divs, toggled via `.active` class:
 
 | Screen ID | Purpose |
 |-----------|---------|
@@ -168,6 +168,7 @@ Six screen divs, toggled via `.active` class:
 | `screen-export` | Generated summary text with copy/email actions |
 | `screen-history` | Game list with swipe-to-delete, resume, and stats access |
 | `screen-config` | League configuration presets and field list management |
+| `screen-about` | App info, version, links (website, privacy, feedback, support) |
 
 ### JavaScript Logic (lines 441-1614)
 
@@ -315,23 +316,28 @@ Hosted on Synology NAS via Web Station. Deploy by copying `website/` contents to
 
 ## Testing
 
-### Manual Testing Checklist
+### Automated E2E Tests
 
-The app does not currently have automated tests. Testing is manual:
+The project has **134 Playwright E2E tests** across 8 spec files, run on every push and PR to `main` via GitHub Actions (`test.yml`).
 
-- [ ] Create new game with home/away pitchers and catchers
-- [ ] Tap pitch button — count increments, alerts appear at thresholds
-- [ ] Next batter — resets batter count, records in break history
-- [ ] Undo — reverses last action correctly
-- [ ] Change pitcher mid-game — old pitcher marked done, new pitcher starts fresh
-- [ ] Score adjustments — +/- buttons update scoreboard
-- [ ] End half inning — switches top/bottom, increments inning
-- [ ] Generate summary — all data appears in formatted text
-- [ ] Copy/email summary — clipboard and mailto: link work
-- [ ] Close and resume game — appears as LIVE in history
-- [ ] End game — saved to history with correct rest-day calculations
-- [ ] Import/export CSV — round-trip data integrity
-- [ ] Config presets — custom thresholds apply to new games
+| Spec file | Tests | Coverage |
+|-----------|-------|----------|
+| `core-game-flow` | 20 | Game lifecycle, scoring, outs (both modes), undo, persistence |
+| `advanced-mode` | 21 | Pitch types, BSO count, BIP modal, auto-advance, non-pitch outs |
+| `thresholds-alerts` | 18 | Rest days, pitch limits, mercy rule modal, at-bat warnings |
+| `pitcher-catcher` | 11 | Roster management, mid-game switches, inning tracking |
+| `summary-export` | 19 | Game summary, umpire data, report generation, export |
+| `shareable-stats` | 18 | Share features, swipe-to-dismiss, image card exports, K/BB/BIP boxes |
+| `history-config` | 19 | History cards, config presets, setup flow, umpire clearing |
+| `about-screen` | 8 | About screen, app info, links, back navigation |
+
+```bash
+npm test              # Run all tests (headless)
+npm run test:headed   # Run with visible browser
+npm run test:ui       # Open Playwright UI
+```
+
+Tests run in Chromium against the web app layer (`index.html`) served locally. Shared helpers (`tests/helpers.ts`) provide utilities for game setup, pitch throwing, and state management.
 
 ### Device Testing
 

--- a/docs/user-guide/user-guide.md
+++ b/docs/user-guide/user-guide.md
@@ -1,7 +1,7 @@
 # Simple Pitch Counter: User Guide
 
-**Version:** 2.0
-**Last updated:** 2026-04-19
+**Version:** 2.2
+**Last updated:** 2026-04-21
 
 ---
 
@@ -239,6 +239,36 @@ The report includes:
 
 - **Copy to clipboard** — paste into text, email, or league app
 - **Email** — opens email with the summary pre-filled
+- **Share** — generates a formatted text report; on iOS, opens the native Share Sheet
+
+---
+
+## Shareable Stats Cards
+
+Stats drawers throughout the app include a **Share** button that generates a dark-themed image card (PNG) you can save or send.
+
+### Where to Share From
+
+| Location | What's shared | How to access |
+|----------|--------------|---------------|
+| Live game pitcher stats | Individual pitcher card | Tap **Stats ›** next to pitcher name → **Share** |
+| Quick stats (mid-game) | All pitchers summary | ☰ → **Quick stats** → **Share** |
+| Game summary pitcher stats | Individual pitcher card | ☰ → **Game summary** → tap pitcher stats button → **Share** |
+| History stats | All pitchers summary | History card → **Stats** → **Share** |
+| History individual pitcher | Individual pitcher card | History card → **Stats** → tap pitcher name → **Share pitcher stats** |
+
+### What's Included
+
+Each image card shows:
+- Pitcher name, team, date, and inning count
+- **K / BB / BIP** hero number boxes
+- Stat lines (pitches, batters, last batter count, rest days)
+- Pitch type breakdown with percentages (Advanced mode)
+- App branding
+
+### Swipe to Dismiss
+
+All stats drawers support **swipe down to dismiss** — drag the sheet downward to close it. A small swipe snaps back; a larger swipe closes the drawer.
 
 ---
 
@@ -270,6 +300,17 @@ The history screen shows all games, newest first. Each card displays:
 4. **Generate the summary before leaving** — the league typically requires the report within 2 hours
 5. **Close, don't end** — if you need to step away, use Close to resume later
 6. **Use physical buttons** — map volume buttons to pitch/undo for eyes-free counting
+
+---
+
+## About This App
+
+Access from the history screen: tap the ☰ menu → **About this app**.
+
+The About screen shows:
+- App name and current version
+- Links to the website, privacy policy, and feedback form
+- A **Buy Me a Coffee** link to support ongoing development
 
 ---
 

--- a/tests/shareable-stats.spec.ts
+++ b/tests/shareable-stats.spec.ts
@@ -234,4 +234,98 @@ test.describe('Shareable stats cards', () => {
     await page.waitForTimeout(300);
     await expect(page.locator('#saved-stats-overlay')).toHaveCount(0);
   });
+
+  test('summary stats drawer shows K BB BIP boxes', async ({ page }) => {
+    await startGame(page, { mode: 'advanced', homeCatcher: 'Mike C.', awayCatcher: 'Dan R.' });
+    await throwPitches(page, 'CS', 3);
+    await throwPitches(page, 'B', 4);
+
+    await page.click('.menu-btn');
+    await page.click('text=Game summary');
+    await page.waitForSelector('#screen-summary.active');
+
+    await page.locator('#screen-summary .stats-btn').first().click();
+    await page.waitForSelector('#sum-stats-overlay .stats-sheet');
+    await expect(page.locator('#sum-stats-overlay .stats-summary-row')).toBeVisible();
+    await expect(page.locator('#sum-stats-overlay .stats-summary-lbl', { hasText: 'K' })).toBeVisible();
+    await expect(page.locator('#sum-stats-overlay .stats-summary-lbl', { hasText: 'BB' })).toBeVisible();
+    await expect(page.locator('#sum-stats-overlay .stats-summary-lbl', { hasText: 'BIP' })).toBeVisible();
+  });
+
+  test('summary stats drawer has Share button', async ({ page }) => {
+    await startGame(page, { mode: 'advanced', homeCatcher: 'Mike C.', awayCatcher: 'Dan R.' });
+    await throwPitches(page, 'B', 3);
+
+    await page.click('.menu-btn');
+    await page.click('text=Game summary');
+    await page.waitForSelector('#screen-summary.active');
+
+    await page.locator('#screen-summary .stats-btn').first().click();
+    await page.waitForSelector('#sum-stats-overlay .stats-sheet');
+
+    const downloadPromise = page.waitForEvent('download', { timeout: 5000 }).catch(() => null);
+    await page.locator('#sum-stats-overlay .stats-sheet').getByText('Share', { exact: true }).click();
+    const download = await downloadPromise;
+    expect(download).not.toBeNull();
+    if (download) {
+      expect(download.suggestedFilename()).toBe('pitcher-stats.png');
+    }
+  });
+
+  test('summary stats drawer supports swipe dismiss', async ({ page }) => {
+    await startGame(page, { mode: 'advanced', homeCatcher: 'Mike C.', awayCatcher: 'Dan R.' });
+    await throwPitches(page, 'B', 3);
+
+    await page.click('.menu-btn');
+    await page.click('text=Game summary');
+    await page.waitForSelector('#screen-summary.active');
+
+    await page.locator('#screen-summary .stats-btn').first().click();
+    await page.waitForSelector('#sum-stats-overlay .stats-sheet');
+
+    const sheet = page.locator('#sum-stats-overlay .stats-sheet');
+    const box = await sheet.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 20);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 200, { steps: 10 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(300);
+    await expect(page.locator('#sum-stats-overlay')).toHaveCount(0);
+  });
+
+  test('live game pitcher stats shows K BB BIP boxes', async ({ page }) => {
+    await startGame(page, { mode: 'advanced', homeCatcher: 'Mike C.', awayCatcher: 'Dan R.' });
+    await throwPitches(page, 'CS', 3);
+    await throwPitches(page, 'B', 2);
+
+    await page.locator('.stats-link').click();
+    await page.waitForSelector('.stats-sheet');
+    const sheet = page.locator('.stats-sheet');
+    await expect(sheet.locator('.stats-summary-row')).toBeVisible();
+    await expect(sheet.locator('.stats-summary-lbl', { hasText: 'K' })).toBeVisible();
+    await expect(sheet.locator('.stats-summary-lbl', { hasText: 'BB' })).toBeVisible();
+    await expect(sheet.locator('.stats-summary-lbl', { hasText: 'BIP' })).toBeVisible();
+  });
+
+  test('history detail expanded pitcher shows K BB BIP boxes', async ({ page }) => {
+    await startGame(page, { mode: 'advanced', homeCatcher: 'Mike C.', awayCatcher: 'Dan R.' });
+    await throwPitches(page, 'CS', 3);
+
+    await page.click('.menu-btn');
+    await page.click('text=End game');
+    await page.click('.modal-btn.red');
+    await expect(page.locator('#screen-history')).toHaveClass(/active/);
+
+    await page.click('text=Stats');
+    await page.waitForSelector('#saved-stats-overlay .stats-sheet');
+
+    const pitcherRow = page.locator('#saved-stats-overlay .stats-sheet').getByText('Jake M.');
+    await pitcherRow.click();
+
+    await expect(page.locator('#saved-stats-overlay .stats-summary-row')).toBeVisible();
+    await expect(page.locator('#saved-stats-overlay .stats-summary-lbl', { hasText: 'K' })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Add 5 new Playwright tests covering summary stats drawer (K/BB/BIP boxes, Share button, swipe dismiss), live game K/BB/BIP boxes, and history detail K/BB/BIP boxes — brings total to **134 tests** across 8 spec files
- Update README: test count 91→134, add shareable-stats and about-screen to test table and project structure, add shareable stats and About screen to feature list
- Update architecture doc: replace manual testing section with automated E2E test info, add `screen-about` to screen table
- Update deployment doc: test counts and add about-screen spec file
- Update user guide: version 2.0→2.2, add Shareable Stats Cards and About This App sections

## Test plan
- [ ] All 134 E2E tests pass in CI
- [ ] Doc test counts match actual spec file counts
- [ ] No broken markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)