### PR TITLE
Update privacy policy for Google Play

### DIFF
--- a/website/privacy.html
+++ b/website/privacy.html
@@ -140,7 +140,7 @@
 
   <div class="policy-section">
     <h2>Overview</h2>
-    <p>Simple Pitch Counter ("the App") is an iOS application designed to help coaches, parents, and volunteers track pitch counts and catcher innings during baseball and softball games.</p>
+    <p>Simple Pitch Counter ("the App") is a mobile application for iOS and Android designed to help coaches, parents, and volunteers track pitch counts and catcher innings during baseball and softball games.</p>
     <p>This Privacy Policy explains how we handle information in connection with your use of the App. We are committed to protecting your privacy and being transparent about our practices.</p>
   </div>
 
@@ -184,8 +184,8 @@
   </div>
 
   <div class="policy-section">
-    <h2>Apple App Store</h2>
-    <p>When you download the App from the Apple App Store, Apple may collect certain information as part of the download process. This is governed by <a href="https://www.apple.com/legal/privacy/" target="_blank" rel="noopener">Apple's Privacy Policy</a>, not ours.</p>
+    <h2>Apple App Store &amp; Google Play</h2>
+    <p>When you download the App from the Apple App Store or Google Play, Apple or Google may collect certain information as part of the download process. This is governed by <a href="https://www.apple.com/legal/privacy/" target="_blank" rel="noopener">Apple's Privacy Policy</a> or <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google's Privacy Policy</a>, not ours.</p>
   </div>
 
   <div class="policy-section">


### PR DESCRIPTION
## Summary
- Update overview to mention Android alongside iOS
- Rename "Apple App Store" section to "Apple App Store & Google Play" with link to Google's privacy policy

## Test plan
- [x] Privacy page renders correctly with updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)