### PR TITLE
Add Android coming soon badge to website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -450,6 +450,17 @@
   .app-store-label { text-align: left; }
   .app-store-label small { display: block; font-size: 0.7rem; opacity: 0.6; letter-spacing: 0.04em; }
   .app-store-label strong { font-size: 1rem; font-weight: 600; }
+  .download-buttons { display: flex; gap: 16px; justify-content: center; align-items: center; flex-wrap: wrap; }
+  .android-coming {
+    display: inline-flex; align-items: center; gap: 12px;
+    background: transparent; color: var(--navy); text-decoration: none;
+    padding: 14px 28px; border-radius: 12px; font-size: 0.9rem; font-weight: 500;
+    border: 1.5px solid rgba(11,28,58,0.2); opacity: 0.7; cursor: default;
+  }
+  .android-coming svg { width: 22px; height: 22px; }
+  .android-coming-label { text-align: left; }
+  .android-coming-label small { display: block; font-size: 0.7rem; opacity: 0.6; letter-spacing: 0.04em; }
+  .android-coming-label strong { font-size: 1rem; font-weight: 600; }
 
   /* ── SUPPORT ── */
   .support {
@@ -576,7 +587,7 @@
 <!-- HERO -->
 <section class="hero">
   <div class="hero-text">
-    <div class="hero-eyebrow">iOS App · Free</div>
+    <div class="hero-eyebrow">iOS App · Free · Android Coming Soon</div>
     <h1>Track every pitch. <em>Every game.</em></h1>
     <p class="hero-sub">Track pitch counts and every pitch type in real time. Simple mode for quick counting, Advanced mode for full ball-strike-out tracking — built for the dugout, not a desk.</p>
     <div class="cta-group">
@@ -800,14 +811,23 @@
 <section class="download" id="download">
   <div class="section-label">Available now</div>
   <h2 class="section-title">Free on the App Store.</h2>
-  <p class="download-sub">Works on iPhone and iPad. No subscription, no ads, no account required.</p>
-  <a href="https://apps.apple.com/us/app/simple-pitch-counter/id6760922314" class="app-store-btn">
-    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
-    <div class="app-store-label">
-      <small>Download on the</small>
-      <strong>App Store</strong>
+  <p class="download-sub">No subscription, no ads, no account required.</p>
+  <div class="download-buttons">
+    <a href="https://apps.apple.com/us/app/simple-pitch-counter/id6760922314" class="app-store-btn">
+      <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
+      <div class="app-store-label">
+        <small>Download on the</small>
+        <strong>App Store</strong>
+      </div>
+    </a>
+    <div class="android-coming">
+      <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.523 2.24l1.39-2.41a.5.5 0 00-.87-.5L16.6 1.74a7.06 7.06 0 00-4.6-1.6 7.06 7.06 0 00-4.6 1.6L5.96-.67a.5.5 0 00-.87.5l1.39 2.41A7.12 7.12 0 003 8.14h18a7.12 7.12 0 00-3.477-5.9zM7 5.64a.75.75 0 110-1.5.75.75 0 010 1.5zm10 0a.75.75 0 110-1.5.75.75 0 010 1.5zM3 9.14v9a1 1 0 001 1h1v3.5a1.5 1.5 0 003 0v-3.5h8v3.5a1.5 1.5 0 003 0v-3.5h1a1 1 0 001-1v-9H3zm-2.5 0a1.5 1.5 0 00-1.5 1.5v5a1.5 1.5 0 003 0v-5a1.5 1.5 0 00-1.5-1.5zm23 0a1.5 1.5 0 00-1.5 1.5v5a1.5 1.5 0 003 0v-5a1.5 1.5 0 00-1.5-1.5z"/></svg>
+      <div class="android-coming-label">
+        <small>Coming soon on</small>
+        <strong>Google Play</strong>
+      </div>
     </div>
-  </a>
+  </div>
 </section>
 
 <!-- SUPPORT -->

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -140,7 +140,7 @@
 
   <div class="policy-section">
     <h2>Overview</h2>
-    <p>Simple Pitch Counter ("the App") is a mobile application for iOS and Android designed to help coaches, parents, and volunteers track pitch counts and catcher innings during baseball and softball games.</p>
+    <p>Simple Pitch Counter ("the App") is an iOS application designed to help coaches, parents, and volunteers track pitch counts and catcher innings during baseball and softball games.</p>
     <p>This Privacy Policy explains how we handle information in connection with your use of the App. We are committed to protecting your privacy and being transparent about our practices.</p>
   </div>
 
@@ -184,8 +184,8 @@
   </div>
 
   <div class="policy-section">
-    <h2>Apple App Store &amp; Google Play</h2>
-    <p>When you download the App from the Apple App Store or Google Play, Apple or Google may collect certain information as part of the download process. This is governed by <a href="https://www.apple.com/legal/privacy/" target="_blank" rel="noopener">Apple's Privacy Policy</a> or <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google's Privacy Policy</a>, not ours.</p>
+    <h2>Apple App Store</h2>
+    <p>When you download the App from the Apple App Store, Apple may collect certain information as part of the download process. This is governed by <a href="https://www.apple.com/legal/privacy/" target="_blank" rel="noopener">Apple's Privacy Policy</a>, not ours.</p>
   </div>
 
   <div class="policy-section">


### PR DESCRIPTION
## Summary
- Add "Coming soon on Google Play" badge next to App Store download button
- Update hero eyebrow to "iOS App · Free · Android Coming Soon"
- Revert privacy policy back to iOS-only (will update when Android goes live)
- Update download section copy to be platform-neutral

## Test plan
- [ ] Verify download section shows both buttons side by side
- [ ] Verify Android badge is non-clickable with muted styling
- [ ] Verify hero eyebrow reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)