### PR TITLE
Add mobile hamburger menu and fix bottom whitespace

### DIFF
--- a/website/android-beta.html
+++ b/website/android-beta.html
@@ -43,6 +43,26 @@
   .nav-links { display: flex; gap: 28px; }
   .nav-links a { color: rgba(247,244,237,0.75); text-decoration: none; font-size: 0.85rem; font-weight: 500; letter-spacing: 0.03em; transition: color 0.2s; }
   .nav-links a:hover { color: #f7f4ed; }
+  .nav-hamburger {
+    display: none; width: 36px; height: 36px;
+    background: rgba(255,255,255,0.1); border: none; border-radius: 8px;
+    cursor: pointer; align-items: center; justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .nav-hamburger svg { display: block; }
+  .nav-overlay {
+    display: none; position: fixed; top: 60px; left: 0; right: 0; bottom: 0;
+    background: rgba(11,28,58,0.98); backdrop-filter: blur(12px); z-index: 99;
+    flex-direction: column; align-items: center; justify-content: flex-start;
+    padding-top: 60px; gap: 8px;
+  }
+  .nav-overlay.open { display: flex; }
+  .nav-overlay a {
+    color: rgba(247,244,237,0.85); text-decoration: none; font-size: 1.1rem;
+    font-weight: 500; padding: 14px 40px; letter-spacing: 0.03em;
+    transition: color 0.2s; width: 100%; text-align: center;
+  }
+  .nav-overlay a:hover { color: #f7f4ed; }
 
   .page-header {
     padding: 130px 8% 70px;
@@ -170,8 +190,9 @@
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
   @media (max-width: 760px) {
-    .beta-wrap { grid-template-columns: 1fr; gap: 50px; padding: 60px 6% 80px; }
+    .beta-wrap { grid-template-columns: 1fr; gap: 40px; padding: 50px 6% 60px; }
     .nav-links { display: none; }
+    .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
   }
@@ -188,7 +209,18 @@
     <a href="contact.html">Contact</a>
     <a href="feedback.html" style="color:#e8a030">Feedback</a>
   </div>
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
+    <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
+  </button>
 </nav>
+<div class="nav-overlay" id="nav-overlay">
+  <a href="/">Home</a>
+  <a href="/#features">Features</a>
+  <a href="/#how-it-works">How it works</a>
+  <a href="privacy.html">Privacy</a>
+  <a href="contact.html">Contact</a>
+  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+</div>
 
 <div class="page-header">
   <div class="page-header-eyebrow">Android Beta</div>
@@ -312,6 +344,11 @@
       submitBtn.textContent = 'Join the Android beta';
     }
   });
+
+  const hamburger = document.getElementById('nav-hamburger');
+  const overlay = document.getElementById('nav-overlay');
+  hamburger.addEventListener('click', () => overlay.classList.toggle('open'));
+  overlay.addEventListener('click', (e) => { if (e.target.tagName === 'A') overlay.classList.remove('open'); });
 </script>
 </body>
 </html>

--- a/website/contact.html
+++ b/website/contact.html
@@ -42,6 +42,26 @@
   .nav-links { display: flex; gap: 28px; }
   .nav-links a { color: rgba(247,244,237,0.75); text-decoration: none; font-size: 0.85rem; font-weight: 500; letter-spacing: 0.03em; transition: color 0.2s; }
   .nav-links a:hover { color: #f7f4ed; }
+  .nav-hamburger {
+    display: none; width: 36px; height: 36px;
+    background: rgba(255,255,255,0.1); border: none; border-radius: 8px;
+    cursor: pointer; align-items: center; justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .nav-hamburger svg { display: block; }
+  .nav-overlay {
+    display: none; position: fixed; top: 60px; left: 0; right: 0; bottom: 0;
+    background: rgba(11,28,58,0.98); backdrop-filter: blur(12px); z-index: 99;
+    flex-direction: column; align-items: center; justify-content: flex-start;
+    padding-top: 60px; gap: 8px;
+  }
+  .nav-overlay.open { display: flex; }
+  .nav-overlay a {
+    color: rgba(247,244,237,0.85); text-decoration: none; font-size: 1.1rem;
+    font-weight: 500; padding: 14px 40px; letter-spacing: 0.03em;
+    transition: color 0.2s; width: 100%; text-align: center;
+  }
+  .nav-overlay a:hover { color: #f7f4ed; }
 
   .page-header {
     padding: 130px 8% 70px;
@@ -193,6 +213,7 @@
     .contact-wrap { grid-template-columns: 1fr; gap: 50px; padding: 60px 6% 80px; }
     .form-row { grid-template-columns: 1fr; }
     .nav-links { display: none; }
+    .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
   }
@@ -209,7 +230,18 @@
     <a href="contact.html">Contact</a>
     <a href="feedback.html" style="color:#e8a030">Feedback</a>
   </div>
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
+    <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
+  </button>
 </nav>
+<div class="nav-overlay" id="nav-overlay">
+  <a href="/">Home</a>
+  <a href="/#features">Features</a>
+  <a href="/#how-it-works">How it works</a>
+  <a href="privacy.html">Privacy</a>
+  <a href="contact.html">Contact</a>
+  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+</div>
 
 <div class="page-header">
   <div class="page-header-eyebrow">Get in touch</div>
@@ -368,6 +400,12 @@
     submitBtn.disabled = false;
     submitBtn.textContent = 'Send message';
   });
+</script>
+<script>
+  const hamburger = document.getElementById('nav-hamburger');
+  const overlay = document.getElementById('nav-overlay');
+  hamburger.addEventListener('click', () => overlay.classList.toggle('open'));
+  overlay.addEventListener('click', (e) => { if (e.target.tagName === 'A') overlay.classList.remove('open'); });
 </script>
 </body>
 </html>

--- a/website/feedback.html
+++ b/website/feedback.html
@@ -42,6 +42,26 @@
   .nav-links { display: flex; gap: 28px; }
   .nav-links a { color: rgba(247,244,237,0.75); text-decoration: none; font-size: 0.85rem; font-weight: 500; letter-spacing: 0.03em; transition: color 0.2s; }
   .nav-links a:hover { color: #f7f4ed; }
+  .nav-hamburger {
+    display: none; width: 36px; height: 36px;
+    background: rgba(255,255,255,0.1); border: none; border-radius: 8px;
+    cursor: pointer; align-items: center; justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .nav-hamburger svg { display: block; }
+  .nav-overlay {
+    display: none; position: fixed; top: 60px; left: 0; right: 0; bottom: 0;
+    background: rgba(11,28,58,0.98); backdrop-filter: blur(12px); z-index: 99;
+    flex-direction: column; align-items: center; justify-content: flex-start;
+    padding-top: 60px; gap: 8px;
+  }
+  .nav-overlay.open { display: flex; }
+  .nav-overlay a {
+    color: rgba(247,244,237,0.85); text-decoration: none; font-size: 1.1rem;
+    font-weight: 500; padding: 14px 40px; letter-spacing: 0.03em;
+    transition: color 0.2s; width: 100%; text-align: center;
+  }
+  .nav-overlay a:hover { color: #f7f4ed; }
 
   .page-header {
     padding: 130px 8% 70px;
@@ -210,6 +230,7 @@
     .form-row { grid-template-columns: 1fr; }
     .type-toggle { flex-direction: column; }
     .nav-links { display: none; }
+    .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
   }
@@ -226,7 +247,18 @@
     <a href="contact.html">Contact</a>
     <a href="feedback.html" style="color:#e8a030">Feedback</a>
   </div>
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
+    <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
+  </button>
 </nav>
+<div class="nav-overlay" id="nav-overlay">
+  <a href="/">Home</a>
+  <a href="/#features">Features</a>
+  <a href="/#how-it-works">How it works</a>
+  <a href="privacy.html">Privacy</a>
+  <a href="contact.html">Contact</a>
+  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+</div>
 
 <div class="page-header">
   <div class="page-header-eyebrow">Help us improve</div>
@@ -448,6 +480,12 @@
       submitBtn.textContent = selectedType === 'bug' ? 'Submit bug report' : 'Submit feature request';
     }
   });
+</script>
+<script>
+  const hamburger = document.getElementById('nav-hamburger');
+  const overlay = document.getElementById('nav-overlay');
+  hamburger.addEventListener('click', () => overlay.classList.toggle('open'));
+  overlay.addEventListener('click', (e) => { if (e.target.tagName === 'A') overlay.classList.remove('open'); });
 </script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -84,6 +84,41 @@
     transition: color 0.2s;
   }
   .nav-links a:hover { color: var(--cream); }
+  .nav-hamburger {
+    display: none;
+    width: 36px; height: 36px;
+    background: rgba(255,255,255,0.1);
+    border: none; border-radius: 8px;
+    cursor: pointer;
+    align-items: center; justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .nav-hamburger svg { display: block; }
+  .nav-overlay {
+    display: none;
+    position: fixed; top: 60px; left: 0; right: 0; bottom: 0;
+    background: rgba(11,28,58,0.98);
+    backdrop-filter: blur(12px);
+    z-index: 99;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding-top: 60px;
+    gap: 8px;
+  }
+  .nav-overlay.open { display: flex; }
+  .nav-overlay a {
+    color: rgba(247,244,237,0.85);
+    text-decoration: none;
+    font-size: 1.1rem;
+    font-weight: 500;
+    padding: 14px 40px;
+    letter-spacing: 0.03em;
+    transition: color 0.2s;
+    width: 100%;
+    text-align: center;
+  }
+  .nav-overlay a:hover { color: #f7f4ed; }
 
   /* ── HERO ── */
   .hero {
@@ -567,10 +602,13 @@
     .features-grid { grid-template-columns: 1fr; }
     .steps { grid-template-columns: 1fr; }
     .nav-links { display: none; }
+    .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
     .phone-frame { width: 220px; }
     .phone-inner { transform: scale(0.52); width: 192.3%; }
+    .download { padding: 60px 6%; }
+    .support { padding: 50px 6%; }
   }
 </style>
 <script src="https://unpkg.com/@phosphor-icons/web@2.1.1"></script>
@@ -590,7 +628,17 @@
     <a href="contact.html">Contact</a>
     <a href="feedback.html" style="color:#e8a030">Feedback</a>
   </div>
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
+    <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
+  </button>
 </nav>
+<div class="nav-overlay" id="nav-overlay">
+  <a href="#features">Features</a>
+  <a href="#how-it-works">How it works</a>
+  <a href="privacy.html">Privacy</a>
+  <a href="contact.html">Contact</a>
+  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+</div>
 
 <!-- HERO -->
 <section class="hero">
@@ -862,5 +910,11 @@
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>
 
+<script>
+  const hamburger = document.getElementById('nav-hamburger');
+  const overlay = document.getElementById('nav-overlay');
+  hamburger.addEventListener('click', () => overlay.classList.toggle('open'));
+  overlay.addEventListener('click', (e) => { if (e.target.tagName === 'A') overlay.classList.remove('open'); });
+</script>
 </body>
 </html>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -39,6 +39,26 @@
   .nav-links { display: flex; gap: 28px; }
   .nav-links a { color: rgba(247,244,237,0.75); text-decoration: none; font-size: 0.85rem; font-weight: 500; letter-spacing: 0.03em; transition: color 0.2s; }
   .nav-links a:hover { color: #f7f4ed; }
+  .nav-hamburger {
+    display: none; width: 36px; height: 36px;
+    background: rgba(255,255,255,0.1); border: none; border-radius: 8px;
+    cursor: pointer; align-items: center; justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .nav-hamburger svg { display: block; }
+  .nav-overlay {
+    display: none; position: fixed; top: 60px; left: 0; right: 0; bottom: 0;
+    background: rgba(11,28,58,0.98); backdrop-filter: blur(12px); z-index: 99;
+    flex-direction: column; align-items: center; justify-content: flex-start;
+    padding-top: 60px; gap: 8px;
+  }
+  .nav-overlay.open { display: flex; }
+  .nav-overlay a {
+    color: rgba(247,244,237,0.85); text-decoration: none; font-size: 1.1rem;
+    font-weight: 500; padding: 14px 40px; letter-spacing: 0.03em;
+    transition: color 0.2s; width: 100%; text-align: center;
+  }
+  .nav-overlay a:hover { color: #f7f4ed; }
 
   .page-header {
     padding: 130px 8% 70px;
@@ -116,7 +136,7 @@
   .footer-links a:hover { color: #f7f4ed; }
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
-  @media (max-width: 600px) { .nav-links { display: none; } footer { flex-direction: column; text-align: center; } .footer-links { flex-wrap: wrap; justify-content: center; } }
+  @media (max-width: 600px) { .nav-links { display: none; } .nav-hamburger { display: flex; } footer { flex-direction: column; text-align: center; } .footer-links { flex-wrap: wrap; justify-content: center; } }
 </style>
 </head>
 <body>
@@ -130,7 +150,18 @@
     <a href="contact.html">Contact</a>
     <a href="feedback.html" style="color:#e8a030">Feedback</a>
   </div>
+  <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
+    <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
+  </button>
 </nav>
+<div class="nav-overlay" id="nav-overlay">
+  <a href="/">Home</a>
+  <a href="/#features">Features</a>
+  <a href="/#how-it-works">How it works</a>
+  <a href="privacy.html">Privacy</a>
+  <a href="contact.html">Contact</a>
+  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+</div>
 
 <div class="page-header">
   <div class="page-header-eyebrow">Legal</div>
@@ -237,5 +268,11 @@
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>
 
+<script>
+  const hamburger = document.getElementById('nav-hamburger');
+  const overlay = document.getElementById('nav-overlay');
+  hamburger.addEventListener('click', () => overlay.classList.toggle('open'));
+  overlay.addEventListener('click', (e) => { if (e.target.tagName === 'A') overlay.classList.remove('open'); });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Added hamburger menu icon on mobile (under 600px on index, under 760px on beta) across all 5 website pages — tapping it opens a full-screen nav overlay with links to all sections
- Reduced bottom padding on homepage download/support sections and beta signup form area to eliminate excessive whitespace on mobile

## Already deployed
All changes are live on the NAS.

## Test plan
- [ ] On mobile, verify hamburger icon appears in top-right of nav
- [ ] Tap hamburger — verify full-screen overlay opens with nav links
- [ ] Tap a link — verify overlay closes and navigates correctly
- [ ] Scroll to bottom — verify no excessive whitespace below content
- [ ] Check all 5 pages: index, android-beta, privacy, contact, feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)