### PR TITLE
Use clean URLs across all website pages

### DIFF
--- a/website/android-beta.html
+++ b/website/android-beta.html
@@ -7,7 +7,7 @@
 <meta property="og:title" content="Android Beta — Simple Pitch Counter">
 <meta property="og:description" content="Sign up to beta test Simple Pitch Counter on Android. Be the first to try it on Google Play.">
 <meta property="og:image" content="https://simplepitchcounter.com/images/og-image-android-beta-1200x630.png">
-<meta property="og:url" content="https://simplepitchcounter.com/android-beta.html">
+<meta property="og:url" content="https://simplepitchcounter.com/android-beta">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <title>Android Beta — Simple Pitch Counter</title>
@@ -205,9 +205,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html" style="color:#e8a030">Feedback</a>
+    <a href="privacy">Privacy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -217,9 +217,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy.html">Privacy</a>
-  <a href="contact.html">Contact</a>
-  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+  <a href="privacy">Privacy</a>
+  <a href="contact">Contact</a>
+  <a href="feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -287,9 +287,9 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="privacy.html">Privacy Policy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html">Feedback</a>
+    <a href="privacy">Privacy Policy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>
@@ -322,7 +322,7 @@
     };
 
     try {
-      const response = await fetch('android-beta.php', {
+      const response = await fetch('/android-beta.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)

--- a/website/contact.html
+++ b/website/contact.html
@@ -6,7 +6,7 @@
 <meta property="og:title" content="Contact — Simple Pitch Counter">
 <meta property="og:description" content="Get in touch with the developer of Simple Pitch Counter.">
 <meta property="og:image" content="https://simplepitchcounter.com/images/og-image-1200x630.png">
-<meta property="og:url" content="https://simplepitchcounter.com/contact.html">
+<meta property="og:url" content="https://simplepitchcounter.com/contact">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <title>Contact — Simple Pitch Counter</title>
@@ -226,9 +226,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html" style="color:#e8a030">Feedback</a>
+    <a href="privacy">Privacy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -238,15 +238,15 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy.html">Privacy</a>
-  <a href="contact.html">Contact</a>
-  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+  <a href="privacy">Privacy</a>
+  <a href="contact">Contact</a>
+  <a href="feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
   <div class="page-header-eyebrow">Get in touch</div>
   <h1>Contact us</h1>
-  <p class="page-header-sub">Questions about the app? We'd love to hear from you. For bugs or feature requests, use our <a href="feedback.html" style="color:#e8a030;text-decoration:none">feedback form</a>.</p>
+  <p class="page-header-sub">Questions about the app? We'd love to hear from you. For bugs or feature requests, use our <a href="feedback" style="color:#e8a030;text-decoration:none">feedback form</a>.</p>
 </div>
 
 <div class="contact-wrap">
@@ -254,7 +254,7 @@
   <!-- Sidebar -->
   <div class="contact-info">
     <h2>We're happy to help.</h2>
-    <p>Whether you have a question about how the app works or need help with something — send us a message. For bugs or feature requests, use our <a href="feedback.html" style="color:#e8a030">feedback form</a>.</p>
+    <p>Whether you have a question about how the app works or need help with something — send us a message. For bugs or feature requests, use our <a href="feedback" style="color:#e8a030">feedback form</a>.</p>
 
     <div class="contact-detail">
       <div class="contact-detail-label">Email</div>
@@ -327,9 +327,9 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="privacy.html">Privacy Policy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html">Feedback</a>
+    <a href="privacy">Privacy Policy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>
@@ -374,7 +374,7 @@
     // On Synology, you can handle this with a PHP script (contact.php)
     // or any other server-side handler. See contact.php included in this package.
     try {
-      const response = await fetch('contact.php', {
+      const response = await fetch('/contact.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ firstName, lastName, email, topic, message })

--- a/website/feedback.html
+++ b/website/feedback.html
@@ -6,7 +6,7 @@
 <meta property="og:title" content="Feedback — Simple Pitch Counter">
 <meta property="og:description" content="Share your feedback about Simple Pitch Counter. Help us improve the app.">
 <meta property="og:image" content="https://simplepitchcounter.com/images/og-image-1200x630.png">
-<meta property="og:url" content="https://simplepitchcounter.com/feedback.html">
+<meta property="og:url" content="https://simplepitchcounter.com/feedback">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <title>Feedback — Simple Pitch Counter</title>
@@ -243,9 +243,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html" style="color:#e8a030">Feedback</a>
+    <a href="privacy">Privacy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -255,9 +255,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy.html">Privacy</a>
-  <a href="contact.html">Contact</a>
-  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+  <a href="privacy">Privacy</a>
+  <a href="contact">Contact</a>
+  <a href="feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -384,9 +384,9 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="privacy.html">Privacy Policy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html">Feedback</a>
+    <a href="privacy">Privacy Policy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>
@@ -451,7 +451,7 @@
     }
 
     try {
-      const response = await fetch('feedback.php', {
+      const response = await fetch('/feedback.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)

--- a/website/index.html
+++ b/website/index.html
@@ -624,9 +624,9 @@
   <div class="nav-links">
     <a href="#features">Features</a>
     <a href="#how-it-works">How it works</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html" style="color:#e8a030">Feedback</a>
+    <a href="privacy">Privacy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -635,9 +635,9 @@
 <div class="nav-overlay" id="nav-overlay">
   <a href="#features">Features</a>
   <a href="#how-it-works">How it works</a>
-  <a href="privacy.html">Privacy</a>
-  <a href="contact.html">Contact</a>
-  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+  <a href="privacy">Privacy</a>
+  <a href="contact">Contact</a>
+  <a href="feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <!-- HERO -->
@@ -876,7 +876,7 @@
         <strong>App Store</strong>
       </div>
     </a>
-    <a href="android-beta.html" class="android-coming">
+    <a href="android-beta" class="android-coming">
       <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.523 2.24l1.39-2.41a.5.5 0 00-.87-.5L16.6 1.74a7.06 7.06 0 00-4.6-1.6 7.06 7.06 0 00-4.6 1.6L5.96-.67a.5.5 0 00-.87.5l1.39 2.41A7.12 7.12 0 003 8.14h18a7.12 7.12 0 00-3.477-5.9zM7 5.64a.75.75 0 110-1.5.75.75 0 010 1.5zm10 0a.75.75 0 110-1.5.75.75 0 010 1.5zM3 9.14v9a1 1 0 001 1h1v3.5a1.5 1.5 0 003 0v-3.5h8v3.5a1.5 1.5 0 003 0v-3.5h1a1 1 0 001-1v-9H3zm-2.5 0a1.5 1.5 0 00-1.5 1.5v5a1.5 1.5 0 003 0v-5a1.5 1.5 0 00-1.5-1.5zm23 0a1.5 1.5 0 00-1.5 1.5v5a1.5 1.5 0 003 0v-5a1.5 1.5 0 00-1.5-1.5z"/></svg>
       <div class="android-coming-label">
         <small>Coming soon on</small>
@@ -903,9 +903,9 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="#features">Features</a>
-    <a href="privacy.html">Privacy Policy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html">Feedback</a>
+    <a href="privacy">Privacy Policy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -6,7 +6,7 @@
 <meta property="og:title" content="Privacy Policy — Simple Pitch Counter">
 <meta property="og:description" content="Simple Pitch Counter does not collect, store, or transmit any personal data. Everything stays on your device.">
 <meta property="og:image" content="https://simplepitchcounter.com/images/og-image-1200x630.png">
-<meta property="og:url" content="https://simplepitchcounter.com/privacy.html">
+<meta property="og:url" content="https://simplepitchcounter.com/privacy">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <title>Privacy Policy — Simple Pitch Counter</title>
@@ -146,9 +146,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html" style="color:#e8a030">Feedback</a>
+    <a href="privacy">Privacy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -158,9 +158,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy.html">Privacy</a>
-  <a href="contact.html">Contact</a>
-  <a href="feedback.html" style="color:#e8a030">Feedback</a>
+  <a href="privacy">Privacy</a>
+  <a href="contact">Contact</a>
+  <a href="feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -250,7 +250,7 @@
     <h2>Contact Us</h2>
     <p>If you have questions about this Privacy Policy or our privacy practices, please contact us:</p>
     <ul>
-      <li><a href="contact.html">Contact form</a> — simplepitchcounter.com/contact</li>
+      <li><a href="contact">Contact form</a> — simplepitchcounter.com/contact</li>
       <li>Email: <a href="mailto:privacy@simplepitchcounter.com">privacy@simplepitchcounter.com</a></li>
     </ul>
   </div>
@@ -261,9 +261,9 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="privacy.html">Privacy Policy</a>
-    <a href="contact.html">Contact</a>
-    <a href="feedback.html">Feedback</a>
+    <a href="privacy">Privacy Policy</a>
+    <a href="contact">Contact</a>
+    <a href="feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>


### PR DESCRIPTION
## Summary
- Removed `.html` extensions from all internal links across all 5 website pages
- Pages now served via directory-based clean URLs (e.g., `simplepitchcounter.com/android-beta/` instead of `simplepitchcounter.com/android-beta.html`)
- PHP form fetch paths changed from relative (`contact.php`) to absolute (`/contact.php`) so forms work correctly from subdirectory URLs
- Old `.html` URLs still work (original files remain in place)

## How it works
Each page exists in two locations on the NAS:
- `/android-beta.html` (backward compatibility)
- `/android-beta/index.html` (clean URL)

Nginx serves `index.html` automatically when a directory is requested.

## Already deployed
All files and directories are live on the NAS.

## Test plan
- [ ] Visit `simplepitchcounter.com/android-beta` — page loads
- [ ] Visit `simplepitchcounter.com/privacy` — page loads
- [ ] Visit `simplepitchcounter.com/contact` — page loads, form submits
- [ ] Visit `simplepitchcounter.com/feedback` — page loads, form submits
- [ ] Old `.html` URLs still work
- [ ] Share `simplepitchcounter.com/android-beta` — URL appears clean in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)