### PR TITLE
Fix Android status bar overlap on non-notch devices

### DIFF
--- a/android/app/src/main/java/com/thamesproductions/pitchcounter/MainActivity.kt
+++ b/android/app/src/main/java/com/thamesproductions/pitchcounter/MainActivity.kt
@@ -73,6 +73,15 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
+            override fun onPageFinished(view: WebView, url: String) {
+                super.onPageFinished(view, url)
+                val statusBarPx = getStatusBarHeight()
+                val statusBarCss = statusBarPx / resources.displayMetrics.density
+                view.evaluateJavascript(
+                    "document.documentElement.style.setProperty('--android-status-bar','${statusBarCss}px')",
+                    null
+                )
+            }
         }
 
         webView.webChromeClient = object : WebChromeClient() {
@@ -199,6 +208,11 @@ class MainActivity : AppCompatActivity() {
         } catch (e: Exception) {
             android.util.Log.e("SimplePitchCounter", "Share failed", e)
         }
+    }
+
+    private fun getStatusBarHeight(): Int {
+        val resId = resources.getIdentifier("status_bar_height", "dimen", "android")
+        return if (resId > 0) resources.getDimensionPixelSize(resId) else 0
     }
 
     inner class WebAppInterface {

--- a/app/index.html
+++ b/app/index.html
@@ -14,6 +14,8 @@
   --blue-bg:#EBF1FF; --green-bg:#E8F9ED; --red-bg:#FFF0EF; --amber-bg:#FFF5E6;
   --dark:#0b1c3a; --dark2:#142a4f; --dark-label:rgba(235,235,245,.6);
   --r:12px; --r-lg:18px; --font:-apple-system,BlinkMacSystemFont,'SF Pro Text','Helvetica Neue',sans-serif;
+  --android-status-bar:0px;
+  --top-inset:max(env(safe-area-inset-top,0px),var(--android-status-bar));
 }
 *{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent}
 html,body{height:100%;background:var(--bg);overscroll-behavior:none;color-scheme:light only}
@@ -31,7 +33,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 /* ── Dark header (scoreboard) ── */
 .dark-header{
   background:var(--dark);
-  padding:calc(env(safe-area-inset-top,0px) + 20px) 18px 16px;
+  padding:calc(var(--top-inset) + 20px) 18px 16px;
   position:relative;
 }
 .inn-bar{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;gap:8px}
@@ -311,7 +313,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 /* ── History screen ── */
 .history-header{
   background:var(--bg);
-  padding:calc(env(safe-area-inset-top,0px) + 20px) 20px 12px;
+  padding:calc(var(--top-inset) + 20px) 20px 12px;
 }
 .history-title-row{display:flex;align-items:flex-end;justify-content:space-between;margin-bottom:12px}
 .history-title{font-size:34px;font-weight:800;letter-spacing:-.5px}
@@ -350,7 +352,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 /* ── Setup screen ── */
 .setup-nav{
   display:flex;align-items:center;justify-content:space-between;
-  padding:calc(env(safe-area-inset-top,0px)+20px) 20px 16px;
+  padding:calc(var(--top-inset)+20px) 20px 16px;
   background:var(--bg);
 }
 .setup-nav-title{font-size:17px;font-weight:700}
@@ -389,7 +391,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 /* ── Summary & Export ── */
 .summary-nav{
   display:flex;align-items:center;justify-content:space-between;
-  padding:calc(env(safe-area-inset-top,0px)+20px) 20px 16px;
+  padding:calc(var(--top-inset)+20px) 20px 16px;
 }
 .summary-nav-title{font-size:17px;font-weight:700}
 .summary-content{padding:0 20px;display:flex;flex-direction:column;gap:16px;
@@ -417,7 +419,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
   margin-bottom:10px;
 }
 /* Config screen */
-.config-nav{padding-top:calc(env(safe-area-inset-top,0px)+20px);padding-left:20px;padding-right:20px;padding-bottom:8px;background:var(--bg)}
+.config-nav{padding-top:calc(var(--top-inset)+20px);padding-left:20px;padding-right:20px;padding-bottom:8px;background:var(--bg)}
 .config-item{display:flex;align-items:flex-start;justify-content:space-between;padding:12px 0;border-bottom:0.5px solid var(--sep)}
 .config-item:last-child{border-bottom:none}
 .config-name{font-size:14px;font-weight:600}
@@ -429,7 +431,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 .trash-btn:active{background:var(--bg)}
 
 /* ── Modal overlay ── */
-.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:500;padding:calc(env(safe-area-inset-top,0px)+20px) 1.2rem calc(env(safe-area-inset-bottom,0px)+1.2rem);overflow-y:auto}
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:500;padding:calc(var(--top-inset)+20px) 1.2rem calc(env(safe-area-inset-bottom,0px)+1.2rem);overflow-y:auto}
 .modal-box{background:var(--card);border-radius:var(--r-lg);padding:1.3rem;width:100%;max-width:360px;position:relative;flex-shrink:0}
 .modal-title{font-size:16px;font-weight:600;margin-bottom:.5rem}
 .modal-sub{font-size:14px;color:var(--t2);margin-bottom:1.1rem;line-height:1.5}


### PR DESCRIPTION
## Summary
- On Android devices without a display cutch (notch), `env(safe-area-inset-top)` returns 0, causing the back button and header content to render behind the status bar
- Native Kotlin shell now measures the actual status bar height and injects it as `--android-status-bar` CSS variable
- New `--top-inset` CSS variable uses `max()` to pick whichever is larger between the safe area env value and the native status bar height
- All 6 top-padding references in `index.html` updated to use `var(--top-inset)`

## Test plan
- [ ] Test on non-notch Android device — back button should clear the status bar
- [ ] Test on notch device (Pixel 3 XL) — no regression, still works correctly
- [ ] Test on iOS — no regression, `--android-status-bar` defaults to 0px

🤖 Generated with [Claude Code](https://claude.com/claude-code)