### PR TITLE
Update docs, README, and website for v2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All changes to `index.html` are documented here. Add this file to the project so
 
 ---
 
+## [2026-04-23] V2.3 — Quality-of-life features and native review prompts
+
+**Files:** `index.html`, `ViewController.swift`, `MainActivity.kt`, `build.gradle.kts`, `project.pbxproj`
+
+### New features
+- **In-game name editing** — edit a pitcher or catcher's name and number mid-game from the Change picker via a pencil icon, without interrupting the game
+- **Called Strike & Ball button mapping** — Advanced mode adds "Called Strike" and "Ball" as physical button options, letting coaches track specific pitch types hands-free like a traditional umpire dial
+- **In-app review prompts** — automatically prompts users to rate the app after games 3, 10, and 25 using native StoreKit (iOS) and Google Play In-App Review API (Android)
+- **Rate This App link** — added to the About screen for manual review access
+
+### Improvements
+- **Pitcher card layout** — game summary pitcher cards now show K/BB totals on a separate line in Advanced mode for better readability
+- **Umpire feedback wording** — "Plate issues?" and "Base issues?" renamed to "Feedback?" with updated placeholder text
+- **Export content** — game summary export now includes innings count, end time range, and updated feedback wording
+- **History card start time** — game cards in history now show the start time alongside the date
+- **Instant navigation** — removed View Transitions API fade effect for instant screen changes
+
+### Testing & versioning
+- Added 23 new E2E tests (`v2-features.spec.ts`) covering all v2.3 features
+- Added version sync test (`version-sync.spec.ts`) enforcing version consistency across Android, iOS, and app UI (134 → 159 total tests)
+- Version bumped to 2.3 across all three locations
+
+---
+
+## [2026-04-23] Android beta polish and website improvements
+
+**Files:** `index.html`, `MainActivity.kt`, `website/index.html`, `website/android-beta.html`, `website/privacy.html`, `website/contact.html`, `website/feedback.html`, `marketing/beta-tester-email.html`, `docs/process/deployment.md`
+
+### Android fixes
+- **Status bar overlap** — inject native status bar height as `--top-inset` CSS variable directly from Kotlin, bypassing CSS `max()` for compatibility with older WebViews
+- **Navigation bar overlap** — inject native nav bar height as `--bottom-inset` CSS variable so Start Game button and all bottom content clear the system nav bar
+- **Header padding** — introduce `--header-pad` variable (20px on iOS, 8px on Android) to tighten gap between status bar and content on Android devices
+- **Status bar text color** — add pre-API-30 fallback using `SYSTEM_UI_FLAG_LIGHT_STATUS_BAR` so status bar text switches to white on the dark game header on older devices
+- **Adaptive icons** — replace legacy PNG launcher icons with adaptive icon (foreground + background layers) supporting circle, squircle, and rounded square launcher shapes
+
+### Website improvements
+- **Hamburger navigation** — added full-screen overlay menu to all 5 pages for mobile navigation
+- **Clean URLs** — switched to directory-based URLs (e.g., `/android-beta/` instead of `/android-beta.html`) using Nginx subdirectory pattern
+- **OG meta tags** — added Open Graph images (1200×630) and meta tags to all pages for link preview support; added `og:image:width`, `og:image:height`, and `twitter:image` for iMessage compatibility
+- **Android beta page** — linked from homepage badge, form submits to PHP backend
+- **Bottom whitespace** — fixed excess padding on mobile for homepage and beta page
+
+### Email system
+- **Confirmation emails** — all three PHP form handlers (contact, feedback, android-beta) now send branded HTML confirmation emails to submitters using table-based layout compatible with Gmail
+- **Beta tester email template** — created Gmail-compatible onboarding email with setup steps, Play Store screenshot, and CTA button; updated to reflect improved Play Store listing (removed warning cards)
+
+### Documentation
+- Added Android deployment procedures to `docs/process/deployment.md`
+- Added clean URL deployment pattern (dual-location SCP)
+
+---
+
 ## [2026-04-19] Simple mode outs, mercy rule, UI refinements
 
 **Files:** `index.html`, `ViewController.swift`, `website/index.html`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is also a portfolio project by **Justin Thames** demonstrating AI-native pr
 
 ## What it does
 
-Simple Pitch Counter tracks pitch counts and catcher innings during live games, enforces league rest-day rules, and generates post-game summary reports — all from your iPhone.
+Simple Pitch Counter tracks pitch counts and catcher innings during live games, enforces league rest-day rules, and generates post-game summary reports — available on iPhone and Android.
 
 ### Key features
 
@@ -30,8 +30,9 @@ Simple Pitch Counter tracks pitch counts and catcher innings during live games, 
 - **Configurable league rules** — set pitch limits, rest-day thresholds, and catcher inning rules per division (e.g., Minors 8, Minors 9/10, Majors)
 - **Threshold awareness** — alerts when a pitcher approaches or crosses a rest-day threshold, with support for the "finish the batter" rule
 - **Catcher/pitcher eligibility** — flags when a catcher has caught 4+ innings (can't pitch) or a pitcher has thrown 41+ pitches (can't catch)
-- **Physical button support** — map iPhone volume buttons and Action Button to pitch counting, undo, or next batter actions with configurable button mapping
-- **Game summaries** — generates a formatted summary with pitcher data, scores, homeruns, pitch type breakdowns, and umpire notes, ready to email
+- **Physical button support** — map volume buttons and Action Button to pitch counting, undo, next batter, or — in Advanced mode — Called Strike and Ball actions, mimicking a traditional umpire tracking dial. Configurable per-button mapping
+- **In-game name editing** — edit a pitcher or catcher's name and number mid-game from the Change picker without interrupting the game
+- **Game summaries** — generates a formatted summary with pitcher data, scores, homeruns, pitch type breakdowns, innings count, end time, and umpire feedback, ready to email
 - **Dark scoreboard header** — persistent dark-themed header with live score, inning/half indicator, and out tracking dots
 - **Score and inning tracking** — built-in scoreboard with inning management
 - **Swipe-to-delete history** — swipe game cards left to reveal delete action; history cards show mode badge (Simple/Advanced) and live game indicator
@@ -40,7 +41,8 @@ Simple Pitch Counter tracks pitch counts and catcher innings during live games, 
 - **Data export/import** — export all game data as JSON (via Share Sheet on iOS) and import backups from the history menu
 - **Pitch dot visualization** — dots below the hero count alternate shading per batter to show at-bat boundaries at a glance
 - **Swipe-to-dismiss stats** — swipe down on any stats bottom sheet to dismiss it
-- **About screen** — accessible from the history menu; shows app version, links to website, privacy policy, feedback form, and Buy Me a Coffee
+- **In-app review prompts** — automatically prompts users to rate the app after games 3, 10, and 25 using native StoreKit (iOS) and Google Play In-App Review (Android)
+- **About screen** — accessible from the history menu; shows app version, Rate This App link, links to website, privacy policy, feedback form, and Buy Me a Coffee
 - **Fully offline** — no account, no internet, no ads. All data stays on your device via localStorage
 
 ### Game summary output
@@ -52,8 +54,9 @@ The app generates summaries matching the EDHLL Game Summary form:
 - Home/away team names and scores
 - Each pitcher: name, actual pitch count (incl. last batter), pitches thrown to last batter
 - Pitch type breakdowns per pitcher (Advanced mode): B, K̲, K, F, BIP counts with K/BB/BIP totals
+- Number of innings played and end time
 - Homeruns (over-the-fence)
-- Umpire summary (plate/base umpire, issues, comments)
+- Umpire summary (plate/base umpire, feedback, comments)
 
 ## Project structure
 
@@ -74,7 +77,9 @@ simple-pitch-counter/
 │   ├── summary-export.spec.ts      # Game summary, report generation, export
 │   ├── shareable-stats.spec.ts     # Share features, swipe-to-dismiss, image cards
 │   ├── history-config.spec.ts      # History cards, config presets, setup flow
-│   └── about-screen.spec.ts        # About screen, links, back navigation
+│   ├── about-screen.spec.ts        # About screen, links, back navigation
+│   ├── v2-features.spec.ts         # V2.3 features: name editing, button mapping, review prompts
+│   └── version-sync.spec.ts        # Version sync across Android, iOS, and app UI
 ├── .github/workflows/      # CI/CD
 │   └── test.yml            # Runs Playwright tests on push/PR to main
 ├── website/                # simplepitchcounter.com
@@ -95,7 +100,7 @@ simple-pitch-counter/
 
 ## Testing
 
-The project has **134 Playwright E2E tests** covering all app functionality:
+The project has **159 Playwright E2E tests** covering all app functionality:
 
 | Spec file | Tests | Coverage |
 |-----------|-------|----------|
@@ -107,6 +112,8 @@ The project has **134 Playwright E2E tests** covering all app functionality:
 | `shareable-stats` | 18 | Share features, swipe-to-dismiss, image card exports, K/BB/BIP boxes |
 | `history-config` | 19 | History cards, config presets, setup flow, umpire clearing |
 | `about-screen` | 8 | About screen, app info, links, back navigation |
+| `v2-features` | 23 | Name editing, button mapping, pitcher card layout, feedback wording, review prompts |
+| `version-sync` | 2 | Version string consistency across Android, iOS, and app UI |
 
 ```bash
 npm test              # Run all tests (headless)
@@ -123,17 +130,29 @@ Tests run automatically on every push and pull request to `main` via GitHub Acti
 The app is a native iOS shell wrapping a single-page web application:
 
 - **AppDelegate.swift** — creates the window and sets `ViewController` as root
-- **ViewController.swift** — configures a `WKWebView` constrained to the safe area, with persistent localStorage, portrait lock, native JS alert/confirm/prompt handling, external link handling, haptic feedback bridge (JS → native via `WKScriptMessageHandler`), dynamic status bar styling (light on game screen, dark elsewhere), and volume button capture for physical button mapping
+- **ViewController.swift** — configures a `WKWebView` constrained to the safe area, with persistent localStorage, portrait lock, native JS alert/confirm/prompt handling, external link handling, haptic feedback bridge (JS → native via `WKScriptMessageHandler`), dynamic status bar styling (light on game screen, dark elsewhere), volume button capture for physical button mapping, and StoreKit in-app review prompts
 - **index.html** — the entire app in one file: HTML structure, CSS styling, and JavaScript logic. Uses localStorage for all data persistence. Features a dark scoreboard header, two game modes (Simple/Advanced), pitch type tracking, out tracking, mercy rule enforcement, and iOS-native visual language
+
+### Android app (`android/`)
+
+The Android app mirrors the iOS architecture — a native Kotlin shell wrapping the same web application:
+
+- **MainActivity.kt** — configures an Android `WebView` with persistent localStorage, portrait lock, native JS alert/confirm/prompt handling, external link handling, haptic feedback bridge (JS → native via `@JavascriptInterface`), dynamic status bar styling with pre-API-30 fallback, volume button capture, Android back button handling, image sharing via `FileProvider`, Google Play In-App Review API prompts, and native inset injection (`--top-inset`, `--bottom-inset`, `--header-pad`) for safe area support across notch and non-notch devices
+- **Adaptive icons** — foreground/background layers supporting circle, squircle, and rounded square launcher masks
+- **index.html** — the same shared web app copied from `app/index.html` into `assets/` at build time via a Gradle `Copy` task
 
 ### Website (`website/`)
 
 A static marketing site hosted on a Synology NAS via Web Station:
 
 - Landing page with interactive phone mockup showing the Advanced mode UI
-- App Store download link and feature highlights
-- Privacy policy (required by App Store)
+- App Store and Google Play download links with feature highlights
+- Android beta signup page with PHP form handler
+- Privacy policy (required by App Store and Google Play)
 - Contact and feedback forms with PHP/SMTP backend
+- Confirmation emails sent to submitters from all three forms
+- Clean URLs via directory-based Nginx routing
+- Open Graph meta tags with branded 1200×630 images for link previews
 - Deployed at simplepitchcounter.com
 
 ## Deployment
@@ -147,11 +166,21 @@ Built and submitted via Xcode on macOS. The `app/index.html` is bundled into the
 3. Xcode → Product → Archive → Distribute to App Store Connect
 4. Build appears in TestFlight automatically
 
+### Android app
+
+Built and submitted via Android Studio. The `app/index.html` is copied into `assets/` by Gradle and loaded by the Android WebView. Version codes auto-increment from git commit count.
+
+1. Push changes to `main`, confirm CI tests pass
+2. Android Studio: pull latest, **Build → Clean Project**
+3. **Build → Generate Signed Bundle** using `upload-keystore.jks`
+4. Upload AAB to Google Play Console → Closed testing → Closed Beta
+5. Currently in closed beta — requires 12 opted-in testers for 14 days before production access
+
 ### Website
 
-Hosted on a self-hosted Synology NAS via Web Station. Deployed via SCP over the local network after any content or mockup changes.
+Hosted on a self-hosted Synology NAS via Web Station (Nginx). Deployed via SCP over the local network after any content or mockup changes. Each page is deployed to two locations for clean URL support (e.g., `android-beta.html` and `android-beta/index.html`).
 
-**Note:** `contact.php` contains SMTP credentials and is excluded from git via `.gitignore`. Connection details (host, port, SSH key) are kept outside the repo.
+**Note:** PHP files (`contact.php`, `feedback.php`, `android-beta.php`) contain SMTP/API credentials and are excluded from git via `.gitignore`. Connection details (host, port, SSH key) are kept outside the repo.
 
 ## License
 
@@ -159,4 +188,4 @@ This project is licensed under the [PolyForm Noncommercial License 1.0.0](LICENS
 
 ## Future plans
 
-- Android support
+- Google Play production release (pending 14-day closed beta tester requirement)

--- a/docs/process/deployment.md
+++ b/docs/process/deployment.md
@@ -41,7 +41,7 @@ Follow conventional style:
 
 ### Automated E2E Tests
 
-134 Playwright tests run on every push and PR to `main` via GitHub Actions (`test.yml`).
+159 Playwright tests run on every push and PR to `main` via GitHub Actions (`test.yml`).
 
 **Test suites:**
 
@@ -55,6 +55,8 @@ Follow conventional style:
 | `shareable-stats.spec.ts` | 18 | Share features, swipe-to-dismiss, image card exports, K/BB/BIP boxes |
 | `history-config.spec.ts` | 19 | History cards, persistence, setup screen, mode toggle, umpire clearing |
 | `about-screen.spec.ts` | 8 | About screen, app info, links, back navigation |
+| `v2-features.spec.ts` | 23 | Name editing, button mapping, pitcher card layout, feedback wording, review prompts |
+| `version-sync.spec.ts` | 2 | Version string consistency across Android, iOS, and app UI |
 
 **Run locally:**
 ```bash
@@ -76,7 +78,11 @@ npm run test:ui          # Interactive Playwright UI
 
 ### Marketing Version
 
-Set manually. Current: **2.2**. Kept in sync between iOS (`MARKETING_VERSION` in Xcode) and Android (`versionName` in `build.gradle.kts`).
+Set manually. Current: **2.3**. Kept in sync across three locations — a Playwright test (`version-sync.spec.ts`) enforces consistency:
+
+1. `android/app/build.gradle.kts` — `versionName`
+2. `app/Little League Pitch Counter.xcodeproj/project.pbxproj` — `MARKETING_VERSION` (Debug and Release)
+3. `app/index.html` — About page "Version X.X" text
 
 Bump schedule:
 - **Patch** (2.0 → 2.1): bug fixes, small improvements
@@ -183,10 +189,10 @@ Pages are served via directory-based URLs (e.g., `simplepitchcounter.com/android
 
 | File | Purpose |
 |------|---------|
-| `android-beta.php` | Android beta signup form mailer (AWS WorkMail SMTP credentials) |
-| `contact.php` | Contact form mailer (AWS WorkMail SMTP credentials) |
-| `feedback.php` | Feedback form → GitHub Issues (GitHub PAT) |
-| `phpmailer/` | PHPMailer library |
+| `android-beta.php` | Android beta signup form mailer + confirmation email (AWS WorkMail SMTP) |
+| `contact.php` | Contact form mailer + confirmation email (AWS WorkMail SMTP) |
+| `feedback.php` | Feedback form → GitHub Issues (GitHub PAT) + confirmation email (AWS WorkMail SMTP) |
+| `phpmailer/` | PHPMailer library (used by all three PHP handlers) |
 
 These files contain credentials and are deployed directly via SCP — never committed to git.
 

--- a/marketing/screenshots.html
+++ b/marketing/screenshots.html
@@ -113,63 +113,53 @@ body{font-family:-apple-system,BlinkMacSystemFont,'SF Pro Text','Helvetica Neue'
 <body>
 
 <!-- ═══════════════════════════════════════════════════════════════ -->
-<!-- SLIDE 1: Advanced Pitch Tracking (phone shifted right)        -->
+<!-- SLIDE 1: Strike & Ball Button Mapping                         -->
 <!--                                                               -->
-<!-- Phone math (scale=2.05, translateX=70px pre-scale):           -->
-<!--   Phone pre-transform center X = 1284/2 = 642                -->
-<!--   After translateX(70): center = 642 + 70*2.05 = 785.5       -->
-<!--   Scaled half-width = 195*2.05 = 399.75                      -->
-<!--   Phone left edge = 785.5 - 399.75 ≈ 386                     -->
-<!--   HW buttons at left:-5px scaled = -10.25px → X ≈ 376        -->
+<!-- Phone shifted RIGHT, scale=1.7 for breathing room.            -->
+<!-- Callouts on the LEFT pointing to volume buttons.              -->
 <!--                                                               -->
-<!--   Phone top Y = headline(~490px) + phone-wrap pad(80) = 570  -->
-<!--   Action center Y = 570 + (90+12)*2.05 = 570+209 = 779      -->
-<!--   Vol-up center Y = 570 + (135+19)*2.05 = 570+316 = 886     -->
-<!--   Vol-dn center Y = 570 + (183+19)*2.05 = 570+414 = 984     -->
+<!-- Phone math (scale=1.7, translateX=100px pre-scale):           -->
+<!--   Phone center X = 642 + (100*1.7) = 812                     -->
+<!--   Scaled half-width = 195*1.7 = 331.5                        -->
+<!--   Phone left edge = 812 - 331.5 ≈ 480                        -->
+<!--   HW vol buttons at left:-5px scaled → X ≈ 472               -->
 <!--                                                               -->
-<!--   All callout lines end at X = 376 (phone left / button X)   -->
+<!--   Phone top Y (measured from screenshot)                      -->
+<!--   Vol-up: top:135px, h:38px → center 154px from phone top    -->
+<!--   Vol-dn: top:183px, h:38px → center 202px from phone top    -->
 <!-- ═══════════════════════════════════════════════════════════════ -->
 <div class="slide" id="slide-1">
   <div class="headline-area">
-    <div class="slide-headline">TRACK<br><span class="green">EVERY PITCH</span></div>
-    <div class="slide-sub">Track every pitch — Ball, Strike, Foul, and Ball in Play</div>
+    <div class="slide-headline">TRACK LIKE<br>AN <span class="amber">UMPIRE</span></div>
+    <div class="slide-sub">Map volume buttons to Strike and Ball — hands-free pitch tracking</div>
   </div>
   <div class="phone-wrap">
     <div class="phone-glow" style="left:65%"></div>
-    <div class="iphone" style="transform:scale(2.05) translateX(70px);transform-origin:top center">
+    <div class="iphone" style="transform:scale(1.7) translateX(140px);transform-origin:top center">
       <div class="hw-action"></div><div class="hw-vol-up"></div><div class="hw-vol-dn"></div><div class="hw-power"></div>
       <div class="iphone-screen"></div>
     </div>
   </div>
 
   <!-- Heading -->
-  <div class="callout-heading" style="right:920px;top:725px">Custom Button Actions</div>
+  <div class="callout-heading" style="right:935px;top:730px">Custom Actions</div>
 
-  <!-- Action button — center Y = 811, callout height 80, top = 811-40 = 771 -->
-  <div class="callout" style="right:908px;top:771px">
-    <div class="callout-text">
-      <div class="callout-name">Action</div>
-      <div class="callout-map" style="color:#FF9500">+ Out</div>
-    </div>
-    <div class="callout-line" style="width:160px;margin-left:20px"></div>
-  </div>
-
-  <!-- Vol Up — center Y = 917, top = 917-40 = 877 -->
-  <div class="callout" style="right:908px;top:877px">
-    <div class="callout-text">
+  <!-- Vol Up → Strike -->
+  <div class="callout" style="right:740px;top:810px">
+    <div class="callout-text" style="align-items:flex-end">
       <div class="callout-name">Vol +</div>
-      <div class="callout-map" style="color:#34C759">Next Batter</div>
+      <div class="callout-map" style="color:#FF3B30">Strike</div>
     </div>
-    <div class="callout-line" style="width:120px;margin-left:20px"></div>
+    <div class="callout-line" style="width:140px;margin-left:20px"></div>
   </div>
 
-  <!-- Vol Down — center Y = 1016, top = 1016-40 = 976 -->
-  <div class="callout" style="right:908px;top:976px">
-    <div class="callout-text">
+  <!-- Vol Down → Ball -->
+  <div class="callout" style="right:740px;top:900px">
+    <div class="callout-text" style="align-items:flex-end">
       <div class="callout-name">Vol &minus;</div>
-      <div class="callout-map" style="color:#FFFFFF">Undo</div>
+      <div class="callout-map" style="color:#1A6BFF">Ball</div>
     </div>
-    <div class="callout-line" style="width:175px;margin-left:20px"></div>
+    <div class="callout-line" style="width:140px;margin-left:20px"></div>
   </div>
 </div>
 
@@ -278,6 +268,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'SF Pro Text','Helvetica Neue'
     </div>
   </div>
 </div>
+
 
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -408,6 +408,192 @@
     font-weight: 300;
   }
 
+  /* ── BUTTON MAPPING ── */
+  .button-mapping {
+    padding: 100px 8%;
+    background: var(--navy);
+    position: relative;
+    overflow: hidden;
+  }
+  .button-mapping::before {
+    content: '';
+    position: absolute;
+    width: 500px; height: 500px;
+    background: radial-gradient(circle, rgba(232,160,48,0.06) 0%, transparent 70%);
+    top: -150px; left: -100px;
+    pointer-events: none;
+  }
+  .bm-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+    gap: 80px;
+  }
+  .bm-text { position: relative; z-index: 1; }
+  .bm-text .section-label { color: var(--gold); }
+  .bm-text .section-title { color: var(--cream); max-width: 480px; }
+  .bm-subtitle {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: rgba(247,244,237,0.65);
+    font-weight: 300;
+    max-width: 440px;
+    margin-bottom: 36px;
+  }
+  .bm-options {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .bm-option {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 14px;
+    padding: 18px 20px;
+  }
+  .bm-option-icon {
+    width: 44px; height: 44px;
+    border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    font-size: 18px; font-weight: 800;
+  }
+  .bm-option-icon.vol-up { background: rgba(255,59,48,0.15); color: #FF6B63; }
+  .bm-option-icon.vol-down { background: rgba(26,107,255,0.15); color: #6FA8FF; }
+  .bm-option-title {
+    font-family: 'DM Serif Display', serif;
+    font-size: 1rem;
+    color: var(--cream);
+    margin-bottom: 3px;
+  }
+  .bm-option-desc {
+    font-size: 0.82rem;
+    color: rgba(247,244,237,0.5);
+    font-weight: 300;
+    line-height: 1.5;
+  }
+  /* Phone with button callouts */
+  .bm-visual {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    z-index: 1;
+  }
+  .bm-phone-wrapper {
+    position: relative;
+  }
+  .bm-phone {
+    width: 280px;
+    background: var(--navy-mid);
+    border: 2px solid rgba(255,255,255,0.12);
+    border-radius: 44px;
+    padding: 14px;
+    box-shadow: 0 40px 80px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.06);
+    position: relative;
+  }
+  .bm-phone-screen {
+    background: #F2F2F7;
+    border-radius: 32px;
+    overflow: hidden;
+    aspect-ratio: 9/19.5;
+    display: flex;
+    flex-direction: column;
+  }
+  .bm-phone-notch {
+    background: #0b1c3a;
+    height: 24px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .bm-phone-notch-pill {
+    width: 74px; height: 18px;
+    background: #000;
+    border-radius: 10px;
+    margin-top: 2px;
+  }
+  .bm-phone-inner {
+    flex: 1;
+    transform: scale(0.66);
+    transform-origin: top left;
+    width: 151.5%;
+    display: flex;
+    flex-direction: column;
+  }
+  /* Volume button callouts on right side of phone */
+  .bm-callout {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    white-space: nowrap;
+  }
+  .bm-callout-right {
+    left: calc(100% + 20px);
+  }
+  .bm-callout-line {
+    width: 40px;
+    height: 1.5px;
+    background: rgba(255,255,255,0.25);
+    position: relative;
+  }
+  .bm-callout-line::after {
+    content: '';
+    position: absolute;
+    left: 0; top: -3px;
+    width: 7px; height: 7px;
+    border-radius: 50%;
+  }
+  .bm-callout-tag {
+    padding: 6px 14px;
+    border-radius: 10px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+  }
+  .bm-callout.strike { top: 28%; }
+  .bm-callout.strike .bm-callout-line::after { background: #FF6B63; }
+  .bm-callout.strike .bm-callout-tag { background: rgba(255,59,48,0.18); color: #FF6B63; border: 1px solid rgba(255,59,48,0.3); }
+  .bm-callout.ball { top: 38%; }
+  .bm-callout.ball .bm-callout-line::after { background: #6FA8FF; }
+  .bm-callout.ball .bm-callout-tag { background: rgba(26,107,255,0.18); color: #6FA8FF; border: 1px solid rgba(26,107,255,0.3); }
+  .bm-btn-label {
+    position: absolute;
+    right: -4px;
+    width: 4px;
+    border-radius: 0 2px 2px 0;
+  }
+  .bm-btn-label.vol-up {
+    top: 26%; height: 36px;
+    background: rgba(255,59,48,0.5);
+  }
+  .bm-btn-label.vol-down {
+    top: 36%; height: 36px;
+    background: rgba(26,107,255,0.5);
+  }
+  @media (max-width: 900px) {
+    .bm-layout { grid-template-columns: 1fr; gap: 50px; }
+    .bm-visual { order: -1; }
+    .bm-phone { width: 220px; }
+    .bm-phone-inner { transform: scale(0.52); width: 192.3%; }
+    .bm-text { text-align: center; }
+    .bm-subtitle { margin: 0 auto 36px; }
+    .bm-callout-right { left: calc(100% + 14px); }
+    .bm-callout-line { width: 28px; }
+    .bm-callout-tag { font-size: 0.72rem; padding: 5px 10px; }
+  }
+  @media (max-width: 600px) {
+    .bm-visual { justify-content: flex-start; padding-left: 10%; }
+    .bm-phone { width: 190px; }
+    .bm-phone-inner { transform: scale(0.45); width: 222.2%; }
+    .bm-callout-right { left: calc(100% + 10px); }
+    .bm-callout-line { width: 20px; }
+    .bm-callout-tag { font-size: 0.68rem; padding: 4px 8px; }
+  }
+
   /* ── HOW IT WORKS ── */
   .how {
     padding: 100px 8%;
@@ -646,7 +832,7 @@
 <!-- HERO -->
 <section class="hero">
   <div class="hero-text">
-    <div class="hero-eyebrow">iOS App · Free · Android Coming Soon</div>
+    <div class="hero-eyebrow">iOS & Android · Free · No Ads</div>
     <h1>Track every pitch. <em>Every game.</em></h1>
     <p class="hero-sub">Track pitch counts and every pitch type in real time. Simple mode for quick counting, Advanced mode for full ball-strike-out tracking — built for the dugout, not a desk.</p>
     <div class="cta-group">
@@ -813,7 +999,7 @@
     <div class="feature-card">
       <div class="feature-icon"><i class="ph-bold ph-device-mobile"></i></div>
       <div class="feature-title">Physical button support</div>
-      <p class="feature-desc">Map your iPhone's volume buttons and Action Button to undo, advance batters, record outs, and more. Keep your eyes on the game, not the screen.</p>
+      <p class="feature-desc">Map volume buttons to Called Strike and Ball in Advanced mode — like an umpire's tracking dial. Also supports undo, next batter, outs, and more.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon"><i class="ph-bold ph-sliders-horizontal"></i></div>
@@ -834,6 +1020,171 @@
       <div class="feature-icon"><i class="ph-bold ph-wifi-slash"></i></div>
       <div class="feature-title">Fully offline</div>
       <p class="feature-desc">No account, no internet required. All data stays on your device. Works in the dugout even without a signal.</p>
+    </div>
+  </div>
+</section>
+
+<!-- BUTTON MAPPING -->
+<section class="button-mapping">
+  <div class="bm-layout">
+    <div class="bm-text">
+      <div class="section-label">Hands-free tracking</div>
+      <h2 class="section-title">Track pitches like an umpire.</h2>
+      <p class="bm-subtitle">Map your phone's volume buttons to record Called Strikes and Balls in Advanced mode — no screen tapping required. Keep your eyes on the field, just like an umpire clicking a tracking dial.</p>
+      <div class="bm-options">
+        <div class="bm-option">
+          <div class="bm-option-icon vol-up">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+          </div>
+          <div>
+            <div class="bm-option-title">Volume Up → Called Strike</div>
+            <div class="bm-option-desc">Records a called strike pitch — the batter watched it go by</div>
+          </div>
+        </div>
+        <div class="bm-option">
+          <div class="bm-option-icon vol-down">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M5 12h14" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+          </div>
+          <div>
+            <div class="bm-option-title">Volume Down → Ball</div>
+            <div class="bm-option-desc">Records a ball — outside the zone, adding to the count</div>
+          </div>
+        </div>
+      </div>
+      <p class="bm-subtitle" style="margin-top:24px;margin-bottom:0;font-size:0.88rem">Fully customizable — you can also map buttons to simple pitch count, next batter, undo, or record outs.</p>
+    </div>
+    <div class="bm-visual">
+      <div class="bm-phone-wrapper">
+        <!-- Volume button indicators on phone edge -->
+        <div class="bm-btn-label vol-up"></div>
+        <div class="bm-btn-label vol-down"></div>
+        <!-- Callout lines on right side -->
+        <div class="bm-callout bm-callout-right strike">
+          <div class="bm-callout-line"></div>
+          <div class="bm-callout-tag">Called Strike</div>
+        </div>
+        <div class="bm-callout bm-callout-right ball">
+          <div class="bm-callout-line"></div>
+          <div class="bm-callout-tag">Ball</div>
+        </div>
+        <div class="bm-phone">
+          <div class="bm-phone-screen">
+            <div class="bm-phone-notch"><div class="bm-phone-notch-pill"></div></div>
+            <div class="bm-phone-inner">
+            <!-- Dark scoreboard header (matches hero) -->
+            <div class="pc-dark-header">
+              <div class="pc-inn-bar">
+                <div style="display:flex;flex-direction:column;align-items:flex-start;gap:1px">
+                  <div style="display:flex;align-items:center;gap:5px">
+                    <div class="pc-inn-pill">▲ TOP 3</div>
+                    <div class="pc-outs">
+                      <div class="pc-out-dot filled"></div>
+                      <div class="pc-out-dot"></div>
+                      <div class="pc-out-dot"></div>
+                    </div>
+                  </div>
+                  <div style="font-size:10px;color:rgba(255,255,255,.5);padding-left:2px">Home fielding</div>
+                </div>
+                <div class="pc-header-actions">
+                  <div class="pc-end-btn">End half ›</div>
+                  <div class="pc-menu-btn"><svg width="16" height="12" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg></div>
+                </div>
+              </div>
+              <div class="pc-sb">
+                <div class="pc-sb-team away">
+                  <div class="pc-sb-name">Away</div>
+                  <div class="pc-sb-score-row">
+                    <div class="pc-sb-adj">−</div>
+                    <div class="pc-sb-num">2</div>
+                    <div class="pc-sb-adj">+</div>
+                  </div>
+                </div>
+                <div class="pc-sb-divider">—</div>
+                <div class="pc-sb-team home">
+                  <div class="pc-sb-name">Home</div>
+                  <div class="pc-sb-score-row">
+                    <div class="pc-sb-adj">−</div>
+                    <div class="pc-sb-num">4</div>
+                    <div class="pc-sb-adj">+</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Light action area (matches hero) -->
+            <div class="pc-action-area">
+              <div class="pc-section-lbl">Pitcher</div>
+              <div class="pc-pitcher-row">
+                <div style="display:flex;align-items:center;gap:5px">
+                  <div class="pc-pitcher-name">Jake M. <span class="pc-pitcher-num">#12</span></div>
+                  <div class="pc-pitch-badge">
+                    <div class="pc-pitch-badge-num">37</div>
+                    <div class="pc-pitch-badge-lbl">pitches</div>
+                  </div>
+                </div>
+                <div class="pc-change-btn">Change</div>
+              </div>
+              <div class="pc-stats-link">Stats ›</div>
+              <!-- Count card -->
+              <div class="pc-count-card">
+                <div class="pc-count-row">
+                  <div class="pc-count-col">
+                    <div class="pc-count-num" style="color:#1A6BFF">3</div>
+                    <div class="pc-count-lbl">Balls</div>
+                  </div>
+                  <div class="pc-count-dot">·</div>
+                  <div class="pc-count-col">
+                    <div class="pc-count-num" style="color:#FF3B30">2</div>
+                    <div class="pc-count-lbl">Strikes</div>
+                  </div>
+                </div>
+                <div class="pc-seq">
+                  <div class="pc-seq-chip" style="background:#EBF1FF;color:#1A6BFF">B</div>
+                  <div class="pc-seq-chip" style="background:#FFF0EF;color:#FF3B30"><svg width="10" height="10" viewBox="0 0 128 128" fill="currentColor" style="vertical-align:-1px"><path d="M110.55 117.41L76.92 63.69l29.73-44.82c.45-.69.5-1.57.1-2.3a2.222 2.222 0 0 0-1.97-1.18H80.34c-.74 0-1.45.38-1.86 1L51.49 57.08V17.64c0-1.24-1.01-2.24-2.24-2.24h-21.9c-1.24 0-2.24 1-2.24 2.24V118.6c0 1.24 1 2.24 2.24 2.24h21.9c1.23 0 2.24-1 2.24-2.24V70.55l30.82 49.24c.41.65 1.13 1.05 1.9 1.05h24.44c.81 0 1.57-.44 1.96-1.16c.39-.71.37-1.58-.06-2.27z" transform="scale(-1,1) translate(-128,0)"/></svg></div>
+                  <div class="pc-seq-chip" style="background:#EBF1FF;color:#1A6BFF">B</div>
+                  <div class="pc-seq-chip" style="background:#FFF5E6;color:#FF9500">F</div>
+                  <div class="pc-seq-chip" style="background:#FFF5E6;color:#FF9500">F</div>
+                  <div class="pc-seq-chip" style="background:#EBF1FF;color:#1A6BFF">B</div>
+                </div>
+              </div>
+              <!-- Pitch buttons -->
+              <div class="pc-pitch-grid">
+                <div class="pc-pitch-row">
+                  <div class="pc-pitch-btn pc-pt-B row1"><span class="pc-pt-glyph">B</span><span class="pc-pt-name">Ball</span></div>
+                  <div class="pc-pitch-btn pc-pt-CS row1"><span class="pc-pt-glyph"><svg width="22" height="22" viewBox="0 0 128 128" fill="currentColor"><path d="M110.55 117.41L76.92 63.69l29.73-44.82c.45-.69.5-1.57.1-2.3a2.222 2.222 0 0 0-1.97-1.18H80.34c-.74 0-1.45.38-1.86 1L51.49 57.08V17.64c0-1.24-1.01-2.24-2.24-2.24h-21.9c-1.24 0-2.24 1-2.24 2.24V118.6c0 1.24 1 2.24 2.24 2.24h21.9c1.23 0 2.24-1 2.24-2.24V70.55l30.82 49.24c.41.65 1.13 1.05 1.9 1.05h24.44c.81 0 1.57-.44 1.96-1.16c.39-.71.37-1.58-.06-2.27z" transform="scale(-1,1) translate(-128,0)"/></svg></span><span class="pc-pt-name">Called K</span></div>
+                  <div class="pc-pitch-btn pc-pt-SS row1"><span class="pc-pt-glyph"><svg width="22" height="22" viewBox="0 0 128 128" fill="currentColor"><path d="M110.55 117.41L76.92 63.69l29.73-44.82c.45-.69.5-1.57.1-2.3a2.222 2.222 0 0 0-1.97-1.18H80.34c-.74 0-1.45.38-1.86 1L51.49 57.08V17.64c0-1.24-1.01-2.24-2.24-2.24h-21.9c-1.24 0-2.24 1-2.24 2.24V118.6c0 1.24 1 2.24 2.24 2.24h21.9c1.23 0 2.24-1 2.24-2.24V70.55l30.82 49.24c.41.65 1.13 1.05 1.9 1.05h24.44c.81 0 1.57-.44 1.96-1.16c.39-.71.37-1.58-.06-2.27z"/></svg></span><span class="pc-pt-name">Swing K</span></div>
+                </div>
+                <div class="pc-pitch-row">
+                  <div class="pc-pitch-btn pc-pt-F row2"><span class="pc-pt-glyph">F</span><span class="pc-pt-name">Foul</span></div>
+                  <div class="pc-pitch-btn pc-pt-BIP row2"><span class="pc-pt-glyph bat-svg"><svg width="24" height="24" viewBox="0 0 496.926 496.926" fill="currentColor"><path d="M227.831,233.153c-17.891,32.025-36.395,65.14-44.667,77.982c-6.072,9.438-28.018,41.875-98.063,142.75c-5.737-1.33-11.915,1.004-15.673,6.473c-2.228,3.242-3.05,7.145-2.333,11.008c0.717,3.854,2.907,7.199,6.139,9.428l19.699,13.541c2.467,1.691,5.345,2.592,8.329,2.592h0.01c4.838,0,9.362-2.383,12.431-6.848c3.471-5.049,3.347-11.59,0.115-16.467c13.091-19.258,83.299-122.496,98.13-142.711c9.018-12.316,33.287-41.424,56.744-69.566c19.298-23.151,37.514-45.021,46.244-56.314c19.106-24.729,50.213-66.909,50.624-67.454l58.379-84.943c11.839-17.222,3.979-30.208-2.036-34.817L400.052,2.792C399.583,2.505,395.299,0,389.188,0c-5.871,0-14.487,2.343-22.156,13.512L308.558,98.58c-0.277,0.44-28.506,44.6-44.753,71.298C256.375,182.061,242.51,206.875,227.831,233.153z"/></svg></span><span class="pc-pt-name">In Play</span></div>
+                </div>
+              </div>
+              <div class="pc-adv-secondary">
+                <span><svg width="14" height="14" viewBox="0 0 24 24" fill="none" style="vertical-align:-2px;margin-right:3px"><path d="M4 17H14.9999C16.8692 17 17.8038 17 18.5 16.5981C18.956 16.3348 19.3348 15.9561 19.5981 15.5C20 14.8038 20 13.8692 20 12C20 10.1308 20 9.19615 19.5981 8.5C19.3348 8.04394 18.9561 7.66523 18.5 7.40193C17.8038 7 16.8692 7 15 7H8M4 17L7 20M4 17L7 14" stroke="currentColor" stroke-width="1.92" stroke-linecap="round" stroke-linejoin="round"/></svg>Undo</span>
+                <span>+ Out</span>
+                <span>Next batter ›</span>
+              </div>
+              <!-- Button hints showing active mapping -->
+              <div class="pc-btn-hints">
+                <div class="pc-btn-hint" style="background:rgba(255,59,48,0.08);border:1px solid rgba(255,59,48,0.2)">
+                  <span class="pc-btn-hint-lbl" style="color:#FF6B63">Vol +</span>
+                  <span class="pc-btn-hint-dot" style="background:#FF3B30"></span>
+                  <span style="font-size:10px;font-weight:700;color:#FF3B30">Called K</span>
+                </div>
+                <div class="pc-btn-hint" style="background:rgba(26,107,255,0.08);border:1px solid rgba(26,107,255,0.2)">
+                  <span class="pc-btn-hint-lbl" style="color:#6FA8FF">Vol −</span>
+                  <span class="pc-btn-hint-dot" style="background:#1A6BFF"></span>
+                  <span style="font-size:10px;font-weight:700;color:#1A6BFF">Ball</span>
+                </div>
+              </div>
+              <div class="pc-alert warn">
+                <div class="pc-alert-dot"></div>
+                <span>37 pitches — approaching 50-pitch limit. 13 remain.</span>
+              </div>
+            </div>
+            </div><!-- end phone-inner -->
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Updated README with v2.3 features (name editing, Called Strike/Ball button mapping, review prompts), 159 test count, 2 new spec files, and StoreKit/Play Review architecture notes
- Added v2.3 CHANGELOG entry covering all 10 features
- Updated deployment docs with new test table, version 2.3 sync enforcement details
- Added new Button Mapping section to website with phone mockup, volume button callouts, and responsive mobile layout
- Updated marketing slide 1 for Strike/Ball volume button callouts

## Test plan
- [ ] Verify website renders correctly at simplepitchcounter.com after deploy
- [ ] Check responsive layout on mobile for new Button Mapping section
- [ ] Confirm all links in README are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)