### PR TITLE
Fix parent's guide content: volunteer framing and catcher context

### DIFF
--- a/website/parents-guide.html
+++ b/website/parents-guide.html
@@ -243,15 +243,15 @@
 <div class="content">
 
   <div class="highlight-box">
-    <p><strong>If this is you, you're not alone.</strong> Every spring, thousands of parents walk up to a Little League field and get handed a clipboard or a phone with zero training. You don't need to know what a changeup is. You just need to count.</p>
+    <p><strong>If this is you, you're not alone.</strong> Every spring, thousands of parents volunteer to help out at their kid's Little League games without realizing what they're signing up for. You don't need to know what a changeup is. You just need to count.</p>
   </div>
 
   <div class="article-section">
     <h2>How You Ended Up Here</h2>
-    <p>Your kid signed up for Little League. Maybe you played softball in high school, maybe you've never held a baseball glove. Either way, you're in the bleachers when the team manager walks over and says, "Hey, can you keep the pitch count today?"</p>
-    <p>And you say yes because that's what parents do.</p>
-    <p>Then you realize you're not totally sure what a pitch count even tracks, or why it matters, or what you're supposed to do with the number when the game is over. You Google it and land on a 40-page PDF of Little League regulations, or an app that wants you to log every play like you're producing an ESPN broadcast.</p>
-    <p>Neither of those things is what you need.</p>
+    <p>Your kid signed up for Little League. The team needs volunteers, so you raise your hand. Maybe you played softball in high school, maybe you've never held a baseball glove. Either way, you figure helping out at games can't be that hard.</p>
+    <p>Then someone mentions you'll need to use an app to track the game. You download it, open it up, and suddenly you're staring at a screen full of baseball terminology you don't recognize. It wants you to log every play, track batting lineups, record fielding positions. You need to know the difference between a wild pitch and a passed ball, between a force out and a fielder's choice. It assumes you already understand the sport.</p>
+    <p>You didn't sign up for that. You signed up to help.</p>
+    <p>The good news is that the most important job at any Little League game doesn't require any baseball knowledge at all. It just requires counting.</p>
   </div>
 
   <div class="article-section">
@@ -259,9 +259,10 @@
     <p>Here's the whole job: every time the kid on the mound throws a pitch, you tap a button. That's it.</p>
     <p>You're not tracking whether it was a ball or a strike (though you can if you want). You're not logging batting lineups or play-by-play. You are literally counting how many times each pitcher throws the ball during live at-bats.</p>
     <p>The reason it matters is straightforward. Little League has rules about how many pitches a kid can throw in a day, and how many days of rest they need afterward. These rules exist because young arms are still growing, and overuse causes real injuries. Torn ligaments, stress fractures, chronic shoulder problems. These aren't hypothetical risks. Pediatric sports doctors see them every season.</p>
+    <p>And it's not just pitchers. Think about the catcher. That kid is throwing the ball back to the pitcher on every single pitch of the game. Their arm is working just as hard. That's why Little League also tracks catcher innings. A player who catches too many innings can't turn around and pitch in the same game. Both positions put stress on young arms, and both need to be monitored.</p>
 
     <div class="pullquote">
-      <p>The pitch count isn't a stat. It's a safety tool. You're protecting a kid's arm.</p>
+      <p>The pitch count isn't a stat. It's a safety tool. You're protecting kids' arms.</p>
     </div>
 
     <p>When you keep an accurate count, the coach knows when to pull a pitcher. And after the game, the count determines how many rest days that player needs before they can pitch again. If the count is wrong, a kid could end up throwing on a day they shouldn't. That's the whole reason your job matters.</p>
@@ -286,9 +287,9 @@
 
   <div class="article-section">
     <h2>The Problem with Complex Apps</h2>
-    <p>If you go looking for an app to help, you'll find ones that want you to track every single play in the game. Ball in play, fielder's choice, stolen base, wild pitch, error on the shortstop. They're designed for serious scorekeepers or travel ball parents who already know what all of that means.</p>
-    <p>For someone who just needs to count pitches and figure out rest days, those apps are overwhelming. You spend half the first inning trying to figure out the interface, and by the time you look up, you've missed three pitches. Now your count is off, and the whole point of being there is accuracy.</p>
-    <p>There's also the cognitive load problem. When an app asks you to make five decisions per pitch (type, result, runners, outs, location), you're not just counting anymore. You're scorekeeping. And if you don't already know the difference between a fielder's choice and a force out, you're going to get stuck, feel embarrassed, and probably stop using the app by the third inning.</p>
+    <p>If you go looking for an app to help, you'll find ones that want you to track every single play in the game. Ball in play, fielder's choice, stolen base, wild pitch, error on the shortstop. These apps assume you already know baseball. They're built for experienced scorekeepers and travel ball parents, not for someone who volunteered last Tuesday.</p>
+    <p>For someone who just needs to count pitches and track rest days, those apps are overwhelming. You spend half the first inning trying to figure out the interface, and by the time you look up, you've missed three pitches. Now your count is off, and the whole point of being there is accuracy.</p>
+    <p>There's also the knowledge barrier. When an app asks you to classify every play and make decisions that require understanding baseball rules, you're not counting anymore. You're scorekeeping. And if you don't know what half the options on the screen mean, you're going to get stuck, feel embarrassed, and probably stop using the app by the third inning.</p>
     <p>None of that complexity is necessary for the actual safety requirement. Little League doesn't need to know if pitch number 34 was a curveball. They need to know it was pitch number 34.</p>
   </div>
 
@@ -297,10 +298,10 @@
     <p>The right tool for this job does three things:</p>
     <ul>
       <li>Counts every pitch with a single tap</li>
-      <li>Tracks how many innings each player has caught (because there are catcher-pitcher rules too)</li>
+      <li>Tracks catcher innings (because both the pitcher and the catcher are throwing on every pitch, and both have limits)</li>
       <li>Calculates rest days automatically so you don't have to look up a chart</li>
     </ul>
-    <p>That's what Simple Pitch Counter does. You open it, start a game, and tap a button every time the pitcher throws. When the pitcher changes, you switch to the next one. At the end of the game, the app tells you how many days of rest each pitcher needs. You can email the summary to the coach right from the app.</p>
+    <p>That's what Simple Pitch Counter does. You open it, start a game, and tap a button every time the pitcher throws. It tracks who's catching too. When the pitcher changes, you switch to the next one. At the end of the game, the app tells you how many days of rest each pitcher needs and flags any catcher-pitcher conflicts. You can email the summary to the coach right from the app.</p>
     <p>There's no account to create. No login. No subscription. No ads. You don't need cell service at the field because everything runs and saves on your phone.</p>
     <p>If you want to track pitch types (balls, strikes, different pitch categories), there's an advanced mode for that. But the simple mode is literally just a counter with a big button. If you can tap a phone screen, you can do this job.</p>
   </div>


### PR DESCRIPTION
## Summary
- Reworked opening: parents volunteer to help, then discover complex apps require baseball knowledge they don't have
- Removed "handed a clipboard or a phone" language
- Added catcher context: both pitcher and catcher throw on every pitch, explaining why both are tracked
- Emphasized the knowledge barrier of complex scorekeeping apps (no names mentioned)

## Test plan
- [ ] Read through the updated article flow at /parents-guide/
- [ ] Verify catcher mentions appear naturally in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)