### PR TITLE
Fix broken links: use absolute paths across all pages

### DIFF
--- a/website/android-beta.html
+++ b/website/android-beta.html
@@ -211,9 +211,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy">Privacy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback" style="color:#e8a030">Feedback</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -223,9 +223,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy">Privacy</a>
-  <a href="contact">Contact</a>
-  <a href="feedback" style="color:#e8a030">Feedback</a>
+  <a href="/privacy">Privacy</a>
+  <a href="/contact">Contact</a>
+  <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -293,11 +293,11 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="pitch-count-rules">Pitch Count Rules</a>
-    <a href="parents-guide">Parent's Guide</a>
-    <a href="privacy">Privacy Policy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback">Feedback</a>
+    <a href="/pitch-count-rules">Pitch Count Rules</a>
+    <a href="/parents-guide">Parent's Guide</a>
+    <a href="/privacy">Privacy Policy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>

--- a/website/contact.html
+++ b/website/contact.html
@@ -230,9 +230,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy">Privacy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback" style="color:#e8a030">Feedback</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -242,15 +242,15 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy">Privacy</a>
-  <a href="contact">Contact</a>
-  <a href="feedback" style="color:#e8a030">Feedback</a>
+  <a href="/privacy">Privacy</a>
+  <a href="/contact">Contact</a>
+  <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
   <div class="page-header-eyebrow">Get in touch</div>
   <h1>Contact us</h1>
-  <p class="page-header-sub">Questions about the app? We'd love to hear from you. For bugs or feature requests, use our <a href="feedback" style="color:#e8a030;text-decoration:none">feedback form</a>.</p>
+  <p class="page-header-sub">Questions about the app? We'd love to hear from you. For bugs or feature requests, use our <a href="/feedback" style="color:#e8a030;text-decoration:none">feedback form</a>.</p>
 </div>
 
 <div class="contact-wrap">
@@ -258,7 +258,7 @@
   <!-- Sidebar -->
   <div class="contact-info">
     <h2>We're happy to help.</h2>
-    <p>Whether you have a question about how the app works or need help with something — send us a message. For bugs or feature requests, use our <a href="feedback" style="color:#e8a030">feedback form</a>.</p>
+    <p>Whether you have a question about how the app works or need help with something — send us a message. For bugs or feature requests, use our <a href="/feedback" style="color:#e8a030">feedback form</a>.</p>
 
     <div class="contact-detail">
       <div class="contact-detail-label">Email</div>
@@ -331,11 +331,11 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="pitch-count-rules">Pitch Count Rules</a>
-    <a href="parents-guide">Parent's Guide</a>
-    <a href="privacy">Privacy Policy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback">Feedback</a>
+    <a href="/pitch-count-rules">Pitch Count Rules</a>
+    <a href="/parents-guide">Parent's Guide</a>
+    <a href="/privacy">Privacy Policy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>

--- a/website/feedback.html
+++ b/website/feedback.html
@@ -247,9 +247,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy">Privacy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback" style="color:#e8a030">Feedback</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -259,9 +259,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy">Privacy</a>
-  <a href="contact">Contact</a>
-  <a href="feedback" style="color:#e8a030">Feedback</a>
+  <a href="/privacy">Privacy</a>
+  <a href="/contact">Contact</a>
+  <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -388,11 +388,11 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="pitch-count-rules">Pitch Count Rules</a>
-    <a href="parents-guide">Parent's Guide</a>
-    <a href="privacy">Privacy Policy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback">Feedback</a>
+    <a href="/pitch-count-rules">Pitch Count Rules</a>
+    <a href="/parents-guide">Parent's Guide</a>
+    <a href="/privacy">Privacy Policy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>

--- a/website/index.html
+++ b/website/index.html
@@ -837,9 +837,9 @@
   <div class="nav-links">
     <a href="#features">Features</a>
     <a href="#how-it-works">How it works</a>
-    <a href="privacy">Privacy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback" style="color:#e8a030">Feedback</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -848,9 +848,9 @@
 <div class="nav-overlay" id="nav-overlay">
   <a href="#features">Features</a>
   <a href="#how-it-works">How it works</a>
-  <a href="privacy">Privacy</a>
-  <a href="contact">Contact</a>
-  <a href="feedback" style="color:#e8a030">Feedback</a>
+  <a href="/privacy">Privacy</a>
+  <a href="/contact">Contact</a>
+  <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <!-- HERO -->
@@ -1254,7 +1254,7 @@
         <strong>App Store</strong>
       </div>
     </a>
-    <a href="android-beta" class="android-coming">
+    <a href="/android-beta" class="android-coming">
       <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.523 2.24l1.39-2.41a.5.5 0 00-.87-.5L16.6 1.74a7.06 7.06 0 00-4.6-1.6 7.06 7.06 0 00-4.6 1.6L5.96-.67a.5.5 0 00-.87.5l1.39 2.41A7.12 7.12 0 003 8.14h18a7.12 7.12 0 00-3.477-5.9zM7 5.64a.75.75 0 110-1.5.75.75 0 010 1.5zm10 0a.75.75 0 110-1.5.75.75 0 010 1.5zM3 9.14v9a1 1 0 001 1h1v3.5a1.5 1.5 0 003 0v-3.5h8v3.5a1.5 1.5 0 003 0v-3.5h1a1 1 0 001-1v-9H3zm-2.5 0a1.5 1.5 0 00-1.5 1.5v5a1.5 1.5 0 003 0v-5a1.5 1.5 0 00-1.5-1.5zm23 0a1.5 1.5 0 00-1.5 1.5v5a1.5 1.5 0 003 0v-5a1.5 1.5 0 00-1.5-1.5z"/></svg>
       <div class="android-coming-label">
         <small>Coming soon on</small>
@@ -1281,11 +1281,11 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="#features">Features</a>
-    <a href="pitch-count-rules">Pitch Count Rules</a>
-    <a href="parents-guide">Parent's Guide</a>
-    <a href="privacy">Privacy Policy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback">Feedback</a>
+    <a href="/pitch-count-rules">Pitch Count Rules</a>
+    <a href="/parents-guide">Parent's Guide</a>
+    <a href="/privacy">Privacy Policy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>

--- a/website/parents-guide.html
+++ b/website/parents-guide.html
@@ -217,9 +217,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy">Privacy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback" style="color:#e8a030">Feedback</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -229,9 +229,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy">Privacy</a>
-  <a href="contact">Contact</a>
-  <a href="feedback" style="color:#e8a030">Feedback</a>
+  <a href="/privacy">Privacy</a>
+  <a href="/contact">Contact</a>
+  <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -331,7 +331,7 @@
       <li><strong>After the game, check rest days</strong> and share the summary with the coach</li>
       <li><strong>If you lose count, ask.</strong> The other team's counter usually has it. It happens, and it's better to ask than guess.</li>
     </ul>
-    <p>For the full rest-day chart and all the specific rules, check out our <a href="pitch-count-rules">complete pitch count rules guide</a>.</p>
+    <p>For the full rest-day chart and all the specific rules, check out our <a href="/pitch-count-rules">complete pitch count rules guide</a>.</p>
   </div>
 
 </div>
@@ -340,11 +340,11 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="pitch-count-rules">Pitch Count Rules</a>
-    <a href="parents-guide">Parent's Guide</a>
-    <a href="privacy">Privacy Policy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback">Feedback</a>
+    <a href="/pitch-count-rules">Pitch Count Rules</a>
+    <a href="/parents-guide">Parent's Guide</a>
+    <a href="/privacy">Privacy Policy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>

--- a/website/pitch-count-rules.html
+++ b/website/pitch-count-rules.html
@@ -240,9 +240,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy">Privacy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback" style="color:#e8a030">Feedback</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -252,9 +252,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy">Privacy</a>
-  <a href="contact">Contact</a>
-  <a href="feedback" style="color:#e8a030">Feedback</a>
+  <a href="/privacy">Privacy</a>
+  <a href="/contact">Contact</a>
+  <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -398,11 +398,11 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="pitch-count-rules">Pitch Count Rules</a>
-    <a href="parents-guide">Parent's Guide</a>
-    <a href="privacy">Privacy Policy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback">Feedback</a>
+    <a href="/pitch-count-rules">Pitch Count Rules</a>
+    <a href="/parents-guide">Parent's Guide</a>
+    <a href="/privacy">Privacy Policy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -150,9 +150,9 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
-    <a href="privacy">Privacy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback" style="color:#e8a030">Feedback</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback" style="color:#e8a030">Feedback</a>
   </div>
   <button class="nav-hamburger" id="nav-hamburger" aria-label="Menu">
     <svg width="18" height="14" viewBox="0 0 18 14" fill="none"><path d="M0 1h18M0 7h18M0 13h18" stroke="rgba(255,255,255,0.7)" stroke-width="1.8" stroke-linecap="round"/></svg>
@@ -162,9 +162,9 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="privacy">Privacy</a>
-  <a href="contact">Contact</a>
-  <a href="feedback" style="color:#e8a030">Feedback</a>
+  <a href="/privacy">Privacy</a>
+  <a href="/contact">Contact</a>
+  <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
 
 <div class="page-header">
@@ -254,7 +254,7 @@
     <h2>Contact Us</h2>
     <p>If you have questions about this Privacy Policy or our privacy practices, please contact us:</p>
     <ul>
-      <li><a href="contact">Contact form</a> — simplepitchcounter.com/contact</li>
+      <li><a href="/contact">Contact form</a> — simplepitchcounter.com/contact</li>
       <li>Email: <a href="mailto:privacy@simplepitchcounter.com">privacy@simplepitchcounter.com</a></li>
     </ul>
   </div>
@@ -265,11 +265,11 @@
   <div class="footer-logo">Simple Pitch Counter</div>
   <div class="footer-links">
     <a href="/">Home</a>
-    <a href="pitch-count-rules">Pitch Count Rules</a>
-    <a href="parents-guide">Parent's Guide</a>
-    <a href="privacy">Privacy Policy</a>
-    <a href="contact">Contact</a>
-    <a href="feedback">Feedback</a>
+    <a href="/pitch-count-rules">Pitch Count Rules</a>
+    <a href="/parents-guide">Parent's Guide</a>
+    <a href="/privacy">Privacy Policy</a>
+    <a href="/contact">Contact</a>
+    <a href="/feedback">Feedback</a>
   </div>
   <div class="footer-copy">&copy; 2026 Simple Pitch Counter. All rights reserved.</div>
 </footer>


### PR DESCRIPTION
## Summary
- Changed all internal links from relative (e.g. `href="privacy"`) to absolute (e.g. `href="/privacy"`) across all 7 website pages
- Fixes 404s when clicking links from clean URL subdirectories like `/parents-guide/`
- Relative links resolved to `/parents-guide/privacy` instead of `/privacy`

## Test plan
- [ ] Click all nav, footer, and in-content links from every subpage
- [ ] Verify pitch count rules link at bottom of parent's guide works

🤖 Generated with [Claude Code](https://claude.com/claude-code)