### PR TITLE
Add cross-links, nav Guides link, sitemap lastmod, ItemList schema

### DIFF
--- a/website/android-beta.html
+++ b/website/android-beta.html
@@ -211,6 +211,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -223,7 +224,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>

--- a/website/articles.html
+++ b/website/articles.html
@@ -160,6 +160,53 @@
     .footer-links { flex-wrap: wrap; justify-content: center; }
   }
 </style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Youth Baseball Guides for Parents and Coaches",
+  "description": "Guides and reference articles for youth baseball parents, coaches, and volunteers.",
+  "numberOfItems": 6,
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "url": "https://simplepitchcounter.com/pitch-count-rules/",
+      "name": "Little League Pitch Count Rules 2026"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "url": "https://simplepitchcounter.com/parents-guide/",
+      "name": "You Don't Need to Know Baseball to Count Pitches"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "url": "https://simplepitchcounter.com/catcher-innings-rules/",
+      "name": "Catcher Rules: How Many Innings Can a Kid Catch?"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "url": "https://simplepitchcounter.com/mercy-rule/",
+      "name": "The Mercy Rule Explained"
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "url": "https://simplepitchcounter.com/what-is-pitch-count/",
+      "name": "What Is a Pitch Counter?"
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "url": "https://simplepitchcounter.com/travel-ball-pitch-counts/",
+      "name": "Travel Ball vs. Rec League Pitch Counts"
+    }
+  ]
+}
+</script>
 </head>
 <body>
 
@@ -168,6 +215,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -180,7 +228,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>

--- a/website/catcher-innings-rules.html
+++ b/website/catcher-innings-rules.html
@@ -143,10 +143,24 @@
   .footer-links a:hover { color: #f7f4ed; }
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
+  .related-guides { margin-top: 60px; padding-top: 40px; border-top: 2px solid var(--cream-dark); }
+  .related-guides h2 {
+    font-family: 'DM Serif Display', serif; font-size: 1.3rem; color: var(--navy); margin-bottom: 20px;
+  }
+  .related-guides-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .related-card {
+    background: #fff; border: 1.5px solid rgba(11,28,58,0.08); border-radius: 10px;
+    padding: 20px; text-decoration: none; transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .related-card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(11,28,58,0.07); }
+  .related-card-title { font-family: 'DM Serif Display', serif; font-size: 0.95rem; color: var(--navy); margin-bottom: 6px; }
+  .related-card-desc { font-size: 0.8rem; color: var(--text-muted); font-weight: 300; line-height: 1.5; }
+
   @media (max-width: 600px) {
     .nav-links { display: none; } .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
+    .related-guides-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
@@ -156,6 +170,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -168,7 +183,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
@@ -285,6 +301,24 @@
     <p>The catcher-pitcher eligibility rules are part of Little League's official regulations and apply to all divisions. Your local league may have additional restrictions, so it's always worth checking with your league's player agent if you have questions about a specific situation.</p>
     <p>For a full breakdown of pitch count limits and rest day requirements by age, see our <a href="/pitch-count-rules">complete pitch count rules guide</a>.</p>
     <p>The official Little League rulebook is updated each year and is available through your local league or on the Little League International website.</p>
+  </div>
+
+  <div class="related-guides">
+    <h2>Related Guides</h2>
+    <div class="related-guides-grid">
+      <a href="/pitch-count-rules" class="related-card">
+        <div class="related-card-title">Pitch Count Rules 2026</div>
+        <div class="related-card-desc">Daily maximums, rest-day charts, and the finish-the-batter rule for every age group.</div>
+      </a>
+      <a href="/mercy-rule" class="related-card">
+        <div class="related-card-title">The Mercy Rule Explained</div>
+        <div class="related-card-desc">How the 10-run rule works and why shortened games don't change rest-day math.</div>
+      </a>
+      <a href="/parents-guide" class="related-card">
+        <div class="related-card-title">Parent's Guide to Pitch Counting</div>
+        <div class="related-card-desc">New to volunteering? Everything you need to know before your first game.</div>
+      </a>
+    </div>
   </div>
 
 </div>

--- a/website/contact.html
+++ b/website/contact.html
@@ -230,6 +230,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -242,7 +243,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>

--- a/website/feedback.html
+++ b/website/feedback.html
@@ -247,6 +247,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -259,7 +260,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>

--- a/website/index.html
+++ b/website/index.html
@@ -901,6 +901,7 @@
   <div class="nav-links">
     <a href="#features">Features</a>
     <a href="#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -912,6 +913,7 @@
 <div class="nav-overlay" id="nav-overlay">
   <a href="#features">Features</a>
   <a href="#how-it-works">How it works</a>
+  <a href="/articles">Guides</a>
   <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>

--- a/website/mercy-rule.html
+++ b/website/mercy-rule.html
@@ -223,11 +223,25 @@
   .footer-links a:hover { color: #f7f4ed; }
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
+  .related-guides { margin-top: 60px; padding-top: 40px; border-top: 2px solid var(--cream-dark); }
+  .related-guides h2 {
+    font-family: 'DM Serif Display', serif; font-size: 1.3rem; color: var(--navy); margin-bottom: 20px;
+  }
+  .related-guides-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .related-card {
+    background: #fff; border: 1.5px solid rgba(11,28,58,0.08); border-radius: 10px;
+    padding: 20px; text-decoration: none; transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .related-card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(11,28,58,0.07); }
+  .related-card-title { font-family: 'DM Serif Display', serif; font-size: 0.95rem; color: var(--navy); margin-bottom: 6px; }
+  .related-card-desc { font-size: 0.8rem; color: var(--text-muted); font-weight: 300; line-height: 1.5; }
+
   @media (max-width: 600px) {
     .nav-links { display: none; }
     .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
+    .related-guides-grid { grid-template-columns: 1fr; }
     .rules-table { font-size: 0.82rem; }
     .rules-table th, .rules-table td { padding: 9px 10px; }
   }
@@ -240,6 +254,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -252,7 +267,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
@@ -364,6 +380,24 @@
     <h2>The Bottom Line</h2>
     <p>The mercy rule is a good thing for youth baseball. It protects kids on the losing end of a blowout and keeps the schedule running smoothly. But a shorter game doesn't mean the pitch count rules take the day off.</p>
     <p>If you're keeping score, keep counting. If you're coaching, check the numbers before you plan your pitching rotation for the next game. And if you're a parent in the stands, don't assume a quick game means your kid's arm got off easy. Look at the actual pitch count. That's the number that matters.</p>
+  </div>
+
+  <div class="related-guides">
+    <h2>Related Guides</h2>
+    <div class="related-guides-grid">
+      <a href="/pitch-count-rules" class="related-card">
+        <div class="related-card-title">Pitch Count Rules 2026</div>
+        <div class="related-card-desc">Daily maximums, rest-day charts, and the finish-the-batter rule for every age group.</div>
+      </a>
+      <a href="/catcher-innings-rules" class="related-card">
+        <div class="related-card-title">Catcher Innings Rules</div>
+        <div class="related-card-desc">How the catcher-pitcher eligibility restrictions work and why both positions are tracked.</div>
+      </a>
+      <a href="/travel-ball-pitch-counts" class="related-card">
+        <div class="related-card-title">Travel Ball vs. Rec League</div>
+        <div class="related-card-desc">How pitch count rules differ between travel organizations and Little League.</div>
+      </a>
+    </div>
   </div>
 
 </div>

--- a/website/parents-guide.html
+++ b/website/parents-guide.html
@@ -202,11 +202,25 @@
   .footer-links a:hover { color: #f7f4ed; }
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
+  .related-guides { margin-top: 60px; padding-top: 40px; border-top: 2px solid var(--cream-dark); }
+  .related-guides h2 {
+    font-family: 'DM Serif Display', serif; font-size: 1.3rem; color: var(--navy); margin-bottom: 20px;
+  }
+  .related-guides-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .related-card {
+    background: #fff; border: 1.5px solid rgba(11,28,58,0.08); border-radius: 10px;
+    padding: 20px; text-decoration: none; transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .related-card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(11,28,58,0.07); }
+  .related-card-title { font-family: 'DM Serif Display', serif; font-size: 0.95rem; color: var(--navy); margin-bottom: 6px; }
+  .related-card-desc { font-size: 0.8rem; color: var(--text-muted); font-weight: 300; line-height: 1.5; }
+
   @media (max-width: 600px) {
     .nav-links { display: none; }
     .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
+    .related-guides-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
@@ -217,6 +231,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -229,7 +244,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
@@ -332,6 +348,24 @@
       <li><strong>If you lose count, ask.</strong> The other team's counter usually has it. It happens, and it's better to ask than guess.</li>
     </ul>
     <p>For the full rest-day chart and all the specific rules, check out our <a href="/pitch-count-rules">complete pitch count rules guide</a>.</p>
+  </div>
+
+  <div class="related-guides">
+    <h2>Related Guides</h2>
+    <div class="related-guides-grid">
+      <a href="/pitch-count-rules" class="related-card">
+        <div class="related-card-title">Pitch Count Rules 2026</div>
+        <div class="related-card-desc">The full rest-day chart and daily maximums for every age group.</div>
+      </a>
+      <a href="/what-is-pitch-count" class="related-card">
+        <div class="related-card-title">What Is a Pitch Counter?</div>
+        <div class="related-card-desc">A deeper look at the volunteer role, what to track, and how it differs from scorekeeping.</div>
+      </a>
+      <a href="/catcher-innings-rules" class="related-card">
+        <div class="related-card-title">Catcher Innings Rules</div>
+        <div class="related-card-desc">Why catchers are tracked and how the catcher-pitcher limits work.</div>
+      </a>
+    </div>
   </div>
 
 </div>

--- a/website/pitch-count-rules.html
+++ b/website/pitch-count-rules.html
@@ -271,6 +271,19 @@
   .footer-links a:hover { color: #f7f4ed; }
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
+  .related-guides { margin-top: 60px; padding-top: 40px; border-top: 2px solid var(--cream-dark); }
+  .related-guides h2 {
+    font-family: 'DM Serif Display', serif; font-size: 1.3rem; color: var(--navy); margin-bottom: 20px;
+  }
+  .related-guides-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .related-card {
+    background: #fff; border: 1.5px solid rgba(11,28,58,0.08); border-radius: 10px;
+    padding: 20px; text-decoration: none; transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .related-card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(11,28,58,0.07); }
+  .related-card-title { font-family: 'DM Serif Display', serif; font-size: 0.95rem; color: var(--navy); margin-bottom: 6px; }
+  .related-card-desc { font-size: 0.8rem; color: var(--text-muted); font-weight: 300; line-height: 1.5; }
+
   @media (max-width: 600px) {
     .nav-links { display: none; }
     .nav-hamburger { display: flex; }
@@ -278,6 +291,7 @@
     .footer-links { flex-wrap: wrap; justify-content: center; }
     .rules-table { font-size: 0.82rem; }
     .rules-table th, .rules-table td { padding: 9px 10px; }
+    .related-guides-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
@@ -288,6 +302,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -300,7 +315,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
@@ -438,6 +454,24 @@
     <p>These rules come from Little League International's official regulations. Your local league may have additional restrictions (some leagues set lower maximums for younger age groups, for example), so always check with your league's player agent or board if you're unsure.</p>
     <p>The official Little League rulebook is updated annually and is available through your local league or on the Little League International website.</p>
     <p>If you have questions about how these rules apply to your league, reach out to your local Little League district administrator. They handle rule interpretation for their area.</p>
+  </div>
+
+  <div class="related-guides">
+    <h2>Related Guides</h2>
+    <div class="related-guides-grid">
+      <a href="/catcher-innings-rules" class="related-card">
+        <div class="related-card-title">Catcher Innings Rules</div>
+        <div class="related-card-desc">How the catcher-pitcher eligibility restrictions work and why both positions are tracked.</div>
+      </a>
+      <a href="/parents-guide" class="related-card">
+        <div class="related-card-title">Parent's Guide to Pitch Counting</div>
+        <div class="related-card-desc">New to volunteering? Everything you need to know before your first game.</div>
+      </a>
+      <a href="/travel-ball-pitch-counts" class="related-card">
+        <div class="related-card-title">Travel Ball vs. Rec League</div>
+        <div class="related-card-desc">How pitch count rules differ between travel organizations and Little League.</div>
+      </a>
+    </div>
   </div>
 
 </div>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -150,6 +150,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -162,7 +163,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,50 +2,62 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://simplepitchcounter.com/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/privacy/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/contact/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/feedback/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/android-beta/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/pitch-count-rules/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/parents-guide/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/articles/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/catcher-innings-rules/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/mercy-rule/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/what-is-pitch-count/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://simplepitchcounter.com/travel-ball-pitch-counts/</loc>
+    <lastmod>2026-04-23</lastmod>
     <priority>0.7</priority>
   </url>
 </urlset>

--- a/website/travel-ball-pitch-counts.html
+++ b/website/travel-ball-pitch-counts.html
@@ -202,11 +202,25 @@
   .footer-links a:hover { color: #f7f4ed; }
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
+  .related-guides { margin-top: 60px; padding-top: 40px; border-top: 2px solid var(--cream-dark); }
+  .related-guides h2 {
+    font-family: 'DM Serif Display', serif; font-size: 1.3rem; color: var(--navy); margin-bottom: 20px;
+  }
+  .related-guides-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .related-card {
+    background: #fff; border: 1.5px solid rgba(11,28,58,0.08); border-radius: 10px;
+    padding: 20px; text-decoration: none; transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .related-card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(11,28,58,0.07); }
+  .related-card-title { font-family: 'DM Serif Display', serif; font-size: 0.95rem; color: var(--navy); margin-bottom: 6px; }
+  .related-card-desc { font-size: 0.8rem; color: var(--text-muted); font-weight: 300; line-height: 1.5; }
+
   @media (max-width: 600px) {
     .nav-links { display: none; }
     .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
+    .related-guides-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
@@ -217,6 +231,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -229,7 +244,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
@@ -339,6 +355,24 @@
     <p>Rec league has pitch count rules built into the system. Travel ball mostly doesn't. That gap doesn't mean travel ball kids are at less risk. It means they're at more risk, because the safety net that rec league provides simply isn't there.</p>
     <p>You can close that gap yourself. Keep a count at every game. Use the Little League rest-day chart as your baseline. Don't let tournament schedules override common sense. And talk to your coach early in the season about how the team plans to manage pitching workloads across the full schedule, not just game by game.</p>
     <p>Your kid's arm is the same arm whether they're throwing in a Wednesday night rec league game or a Sunday afternoon tournament championship. Protect it the same way.</p>
+  </div>
+
+  <div class="related-guides">
+    <h2>Related Guides</h2>
+    <div class="related-guides-grid">
+      <a href="/pitch-count-rules" class="related-card">
+        <div class="related-card-title">Pitch Count Rules 2026</div>
+        <div class="related-card-desc">The official Little League rest-day charts and daily maximums by age.</div>
+      </a>
+      <a href="/mercy-rule" class="related-card">
+        <div class="related-card-title">The Mercy Rule Explained</div>
+        <div class="related-card-desc">How the 10-run rule works and why shortened games don't change rest-day math.</div>
+      </a>
+      <a href="/parents-guide" class="related-card">
+        <div class="related-card-title">Parent's Guide to Pitch Counting</div>
+        <div class="related-card-desc">New to volunteering? Everything you need to know before your first game.</div>
+      </a>
+    </div>
   </div>
 
 </div>

--- a/website/what-is-pitch-count.html
+++ b/website/what-is-pitch-count.html
@@ -202,11 +202,25 @@
   .footer-links a:hover { color: #f7f4ed; }
   .footer-copy { color: rgba(247,244,237,0.3); font-size: 0.78rem; width: 100%; text-align: center; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.05); margin-top: 8px; }
 
+  .related-guides { margin-top: 60px; padding-top: 40px; border-top: 2px solid var(--cream-dark); }
+  .related-guides h2 {
+    font-family: 'DM Serif Display', serif; font-size: 1.3rem; color: var(--navy); margin-bottom: 20px;
+  }
+  .related-guides-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .related-card {
+    background: #fff; border: 1.5px solid rgba(11,28,58,0.08); border-radius: 10px;
+    padding: 20px; text-decoration: none; transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .related-card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(11,28,58,0.07); }
+  .related-card-title { font-family: 'DM Serif Display', serif; font-size: 0.95rem; color: var(--navy); margin-bottom: 6px; }
+  .related-card-desc { font-size: 0.8rem; color: var(--text-muted); font-weight: 300; line-height: 1.5; }
+
   @media (max-width: 600px) {
     .nav-links { display: none; }
     .nav-hamburger { display: flex; }
     footer { flex-direction: column; text-align: center; }
     .footer-links { flex-wrap: wrap; justify-content: center; }
+    .related-guides-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
@@ -217,6 +231,7 @@
   <div class="nav-links">
     <a href="/#features">Features</a>
     <a href="/#how-it-works">How it works</a>
+    <a href="/articles">Guides</a>
     <a href="/privacy">Privacy</a>
     <a href="/contact">Contact</a>
     <a href="/feedback" style="color:#e8a030">Feedback</a>
@@ -229,7 +244,8 @@
   <a href="/">Home</a>
   <a href="/#features">Features</a>
   <a href="/#how-it-works">How it works</a>
-  <a href="/privacy">Privacy</a>
+  <a href="/articles">Guides</a>
+    <a href="/privacy">Privacy</a>
   <a href="/contact">Contact</a>
   <a href="/feedback" style="color:#e8a030">Feedback</a>
 </div>
@@ -348,6 +364,24 @@
     <p>Youth arm injuries from overuse are preventable. The pitch count rules exist for exactly that reason. But rules only work when someone bothers to enforce them, and enforcement starts with a parent in a camping chair doing the counting.</p>
     <p>You don't need to understand earned run averages or the infield fly rule. You need to watch the pitcher and tap. That's a job any parent can do, and it's one of the most useful things you can volunteer for at the field.</p>
     <p>For a step-by-step walkthrough of your first game as a pitch counter, check out our <a href="/parents-guide">parent's guide to pitch counting</a>.</p>
+  </div>
+
+  <div class="related-guides">
+    <h2>Related Guides</h2>
+    <div class="related-guides-grid">
+      <a href="/parents-guide" class="related-card">
+        <div class="related-card-title">Parent's Guide to Pitch Counting</div>
+        <div class="related-card-desc">The full story on volunteering at the field, written for parents new to baseball.</div>
+      </a>
+      <a href="/pitch-count-rules" class="related-card">
+        <div class="related-card-title">Pitch Count Rules 2026</div>
+        <div class="related-card-desc">Daily maximums, rest-day charts, and the finish-the-batter rule for every age group.</div>
+      </a>
+      <a href="/catcher-innings-rules" class="related-card">
+        <div class="related-card-title">Catcher Innings Rules</div>
+        <div class="related-card-desc">How the catcher-pitcher eligibility restrictions work and why both positions are tracked.</div>
+      </a>
+    </div>
   </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Added "Related Guides" section with 3 contextually relevant article cards at the bottom of all 6 article pages
- Added "Guides" link (pointing to /articles) in desktop nav and mobile overlay on all 12 pages
- Added `<lastmod>2026-04-23</lastmod>` to all 12 entries in sitemap.xml
- Added ItemList JSON-LD structured data to the articles index page listing all 6 guides

## Test plan
- [ ] Verify "Guides" nav link appears and works on desktop and mobile across all pages
- [ ] Verify Related Guides cards at bottom of each article page link to correct articles
- [ ] Validate sitemap.xml at https://simplepitchcounter.com/sitemap.xml
- [ ] Test ItemList schema with Google Rich Results Test
- [ ] Check responsive layout of related guides grid on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)