### PR TITLE
Unify button mapping options across simple and advanced modes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1707,9 +1707,7 @@ function showPitcherStats(){
 
 // ── Button mapping modal ──
 function getBtnMapOpts(){
-  const g=state.currentGame;
-  if(g&&g.mode==='advanced')return['calledStrike','ball','nextBatter','undo','recordOut','none'];
-  return['pitch','nextBatter','undo','none'];
+  return['pitch','calledStrike','ball','nextBatter','undo','recordOut','none'];
 }
 function getBtnRows(){
   const showAction=hasActionButton();


### PR DESCRIPTION
## Summary
- Simple mode button mapping now shows all the same actions as advanced mode: Called Strike, Ball, + Out, Pitch, Next Batter, Undo, and Off
- When Called Strike or Ball is mapped to a hardware button in simple mode, it counts the pitch, tracks the ball/strike count, and auto-advances the batter on strikeouts and walks

## Test plan
- [ ] Open a simple mode game, go to Button mapping, verify all 7 options appear for each button
- [ ] Map Vol Up to Called Strike, Vol Down to Ball — verify pitches count and batter auto-advances on K/BB
- [ ] Open an advanced mode game, verify button mapping still shows same options
- [ ] Verify existing simple mode default mappings (Vol Up = + Pitch, Vol Down = Undo) are unchanged for new games

🤖 Generated with [Claude Code](https://claude.com/claude-code)