### PR TITLE
Fix 10 bugs and add features (#94-#103)

### DIFF
--- a/android/app/src/main/assets/index.html
+++ b/android/app/src/main/assets/index.html
@@ -99,7 +99,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 .inn-scoreboard::-webkit-scrollbar{display:none}
 .inn-sb-col{display:flex;flex-direction:column;align-items:center;min-width:24px;flex-shrink:0}
 .inn-sb-col.lbl{min-width:32px;align-items:flex-start}
-.inn-sb-hdr{font-size:9px;font-weight:700;color:rgba(235,235,245,.35);letter-spacing:.3px;padding:0 2px 2px;text-transform:uppercase;height:15px;display:flex;align-items:flex-end}
+.inn-sb-hdr{font-size:9px;font-weight:700;color:rgba(235,235,245,.35);letter-spacing:.3px;padding:0 2px 2px;text-transform:uppercase;height:15px;display:flex;align-items:flex-end;justify-content:center}
 .inn-sb-cell{font-size:11px;font-weight:600;color:rgba(255,255,255,.7);padding:1px 2px;text-align:center;min-width:24px;line-height:15px;height:17px;display:flex;align-items:center;justify-content:center}
 .inn-sb-cell.current{color:#fff;font-weight:800}
 .inn-sb-cell.total{color:#fff;font-weight:800;font-size:12px}
@@ -355,7 +355,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 .hist-scoreboard::-webkit-scrollbar{display:none}
 .hist-sb-col{display:flex;flex-direction:column;align-items:center;min-width:20px;flex-shrink:0}
 .hist-sb-col.lbl{min-width:28px;align-items:flex-start}
-.hist-sb-hdr{font-size:8px;font-weight:700;color:var(--t3);letter-spacing:.3px;text-transform:uppercase;height:14px;display:flex;align-items:flex-end}
+.hist-sb-hdr{font-size:8px;font-weight:700;color:var(--t3);letter-spacing:.3px;text-transform:uppercase;height:14px;display:flex;align-items:flex-end;justify-content:center}
 .hist-sb-cell{font-size:10px;font-weight:600;color:var(--text);padding:1px 2px;text-align:center;min-width:20px;line-height:14px;height:16px;display:flex;align-items:center;justify-content:center}
 .hist-sb-cell.total{font-weight:800;font-size:11px}
 .rest-section{border-top:1px solid var(--sep);padding:10px 16px}
@@ -739,6 +739,13 @@ textarea{resize:vertical;min-height:56px}
     <div style="width:70px"></div>
   </div>
   <div class="summary-content">
+    <!-- Division -->
+    <div>
+      <div class="section-header-lbl">Division</div>
+      <div class="form-card">
+        <div class="form-row" style="border-bottom:none"><div class="form-row-lbl">Division</div><input class="form-input" id="sum-division" placeholder="e.g. Minors 8 or AA" autocapitalize="words"></div>
+      </div>
+    </div>
     <!-- HR fields -->
     <div>
       <div class="section-header-lbl">Home Runs</div>
@@ -916,7 +923,7 @@ const PT_TYPES = {
   BIP:{label:'<svg width="12" height="12" viewBox="0 0 496.926 496.926" fill="currentColor" style="vertical-align:-1px"><path d="M227.831,233.153c-17.891,32.025-36.395,65.14-44.667,77.982c-6.072,9.438-28.018,41.875-98.063,142.75c-5.737-1.33-11.915,1.004-15.673,6.473c-2.228,3.242-3.05,7.145-2.333,11.008c0.717,3.854,2.907,7.199,6.139,9.428l19.699,13.541c2.467,1.691,5.345,2.592,8.329,2.592h0.01c4.838,0,9.362-2.383,12.431-6.848c3.471-5.049,3.347-11.59,0.115-16.467c13.091-19.258,83.299-122.496,98.13-142.711c9.018-12.316,33.287-41.424,56.744-69.566c19.298-23.151,37.514-45.021,46.244-56.314c19.106-24.729,50.213-66.909,50.624-67.454l58.379-84.943c11.839-17.222,3.979-30.208-2.036-34.817L400.052,2.792C399.583,2.505,395.299,0,389.188,0c-5.871,0-14.487,2.343-22.156,13.512L308.558,98.58c-0.277,0.44-28.506,44.6-44.753,71.298C256.375,182.061,242.51,206.875,227.831,233.153z"/></svg>',  name:'In Play',     color:'#34C759',bg:'#E8F9ED'},
 };
 const DEFAULT_THRESHOLDS=[{pitches:20,days:0},{pitches:35,days:1},{pitches:50,days:2}];
-let PITCH_MAX=50, C_INN_LIM=4, PITCH_C_LIM=41, MERCY_RUNS=0;
+let PITCH_MAX=50, C_INN_LIM=4, PITCH_C_LIM=41, MERCY_RUNS=0, MERCY_GAME=0, MAX_INN=6;
 const BATTER_WARN=6, BATTER_CRIT=9;
 let selectedMode='simple'; // for setup
 
@@ -928,7 +935,7 @@ function loadState(){
   if(!state.configs)state.configs=[];
   if(!state.fields)state.fields=[];
   if(!state.configs.length){
-    state.configs.push({id:'default',name:'Default Minors 7-10',pitchMax:50,catcherInnMax:4,mercyRuns:5,pitchCatchLim:41,isDefault:true,thresholds:JSON.parse(JSON.stringify(DEFAULT_THRESHOLDS))});
+    state.configs.push({id:'default',name:'Default Minors 7-10',pitchMax:50,catcherInnMax:4,mercyRuns:5,pitchCatchLim:41,mercyGame:0,maxInnings:6,isDefault:true,thresholds:JSON.parse(JSON.stringify(DEFAULT_THRESHOLDS))});
     state.activeConfigId='default';
   }
   state.configs.forEach(c=>{if(!c.thresholds)c.thresholds=JSON.parse(JSON.stringify(DEFAULT_THRESHOLDS));});
@@ -943,7 +950,7 @@ function saveState(){try{localStorage.setItem('spc_v1',JSON.stringify(state));}c
 function saveBtnMapping(){const g=state.currentGame;const mode=g?g.mode:'simple';try{localStorage.setItem('spc_btnmap_'+mode,JSON.stringify(btnMapping));}catch(e){}}
 function applyActiveConfig(){
   const cfg=state.configs.find(c=>c.id===state.activeConfigId)||state.configs[0];
-  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;}
+  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
 }
 
 // ── Navigation ──
@@ -1142,7 +1149,18 @@ function adjScore(side,d){
   haptic('selection');saveState();renderGame();
   if(d>0&&MERCY_RUNS>0&&g.halfInningRuns>=MERCY_RUNS){
     confirmMercyEnd();
+  }else if(d>0&&MERCY_GAME>0&&Math.abs(g.homeScore-g.awayScore)>=MERCY_GAME){
+    confirmMercyGameEnd();
   }
+}
+function confirmMercyGameEnd(){
+  const g=state.currentGame;if(!g)return;
+  const diff=Math.abs(g.homeScore-g.awayScore);
+  const leader=g.homeScore>g.awayScore?g.homeTeam:g.awayTeam;
+  showModal('Game mercy reached',`${leader} leads by ${diff} runs — ${MERCY_GAME}-run game mercy limit reached.`,[
+    {label:'Continue',fn:'closeModal()'},
+    {label:'End game',fn:'closeModal();confirmEndGame()',cls:'red'},
+  ]);
 }
 function confirmMercyEnd(){
   const g=state.currentGame;if(!g)return;
@@ -1167,8 +1185,8 @@ function recordNonPitchOut(){
 }
 
 // ── Half inning ──
-function endHalfInning(){
-  pushSnap();
+function endHalfInning(skipSnap){
+  if(!skipSnap)pushSnap();
   const g=state.currentGame;
   const ap=activePitcher();
   if(ap&&ap.currentBatterPitches>0){ap.batterBreaks.push(ap.currentBatterPitches);ap.lastBatterPitches=ap.currentBatterPitches;ap.currentBatterPitches=0;}
@@ -1186,7 +1204,8 @@ function endHalfInning(){
   g.balls=0;g.strikes=0;g.outs=0;g.atBatLog=[];g.halfInningRuns=0;
   g.pSelectOpen=false;g.cSelectOpen=false;
   haptic('success');saveState();renderGame();window.scrollTo(0,0);
-  if(g.inning>9&&g.isTop&&g.homeScore!==g.awayScore){
+  const innLimit=MAX_INN||9;
+  if(g.inning>innLimit&&g.isTop&&g.homeScore!==g.awayScore){
     showModal('Game complete',`${g.inning-1} innings played. ${g.homeScore>g.awayScore?g.homeTeam:g.awayTeam} wins ${Math.max(g.homeScore,g.awayScore)}–${Math.min(g.homeScore,g.awayScore)}.`,[
       {label:'Continue playing',fn:'closeModal()'},
       {label:'End game',fn:'closeModal();confirmEndGame()',cls:'red'},
@@ -1271,7 +1290,7 @@ function confirmSideRetired(){
   const g=state.currentGame;if(!g)return;
   showModal('End half inning?',`3 outs recorded — end the ${g.isTop?'Top':'Bottom'} of Inning ${g.inning}?`,[
     {label:'Undo',fn:'closeModal();undoLast()'},
-    {label:'End',fn:'closeModal();setTimeout(endHalfInning,50)',cls:'amber'},
+    {label:'End',fn:'closeModal();setTimeout(()=>endHalfInning(true),50)',cls:'amber'},
   ]);
 }
 function doNextBatter(){
@@ -1349,7 +1368,7 @@ function editInningCell(innIdx,half){
 function renderGame(){
   const g=state.currentGame;if(!g)return;
   const cfg=state.configs.find(c=>c.id===g.configId);
-  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;}
+  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
   // Scoreboard
   document.getElementById('sb-home-name').textContent=g.homeTeam;
   document.getElementById('sb-away-name').textContent=g.awayTeam;
@@ -1484,6 +1503,7 @@ function addNewPitcherMidGame(){
   const n=document.getElementById('new-p-name')?.value.trim();if(!n){alert('Enter pitcher name.');return;}
   const nu=document.getElementById('new-p-num')?.value.trim()||'';
   fRoster().pitchers.push(mkPitcher(n,nu));
+  setPI(fRoster().pitchers.length-1);
   saveState();renderGame();
 }
 
@@ -1553,11 +1573,17 @@ function pitchAlerts(p){
 }
 function mercyAlerts(){
   const a=[];
-  if(!MERCY_RUNS||MERCY_RUNS<=0)return a;
   const g=state.currentGame;if(!g)return a;
-  const runs=g.halfInningRuns||0;
-  if(runs>=MERCY_RUNS)a.push({t:'danger',m:`${runs} runs scored this half inning — ${MERCY_RUNS}-run mercy limit reached.`});
-  else if(runs>=MERCY_RUNS-1)a.push({t:'warn',m:`${runs} runs scored — 1 away from ${MERCY_RUNS}-run mercy limit.`});
+  if(MERCY_RUNS>0){
+    const runs=g.halfInningRuns||0;
+    if(runs>=MERCY_RUNS)a.push({t:'danger',m:`${runs} runs scored this half inning — ${MERCY_RUNS}-run mercy limit reached.`});
+    else if(runs>=MERCY_RUNS-1)a.push({t:'warn',m:`${runs} runs scored — 1 away from ${MERCY_RUNS}-run mercy limit.`});
+  }
+  if(MERCY_GAME>0){
+    const diff=Math.abs(g.homeScore-g.awayScore);
+    if(diff>=MERCY_GAME)a.push({t:'danger',m:`Run differential is ${diff} — ${MERCY_GAME}-run game mercy limit reached.`});
+    else if(diff>=MERCY_GAME-1&&diff>0)a.push({t:'warn',m:`Run differential is ${diff} — 1 away from ${MERCY_GAME}-run game mercy limit.`});
+  }
   return a;
 }
 
@@ -1821,7 +1847,7 @@ function getBtnRows(){
       <div style="font-size:12px;font-weight:700;color:rgba(235,235,245,.6);text-transform:uppercase;letter-spacing:.6px;margin-bottom:2px">${label}</div>
       <div style="font-size:11px;color:rgba(235,235,245,.35);margin-bottom:8px">${sub}</div>
       <div style="display:flex;gap:6px">
-        ${opts.map(opt=>`<div onclick="setBtnMapping('${key}','${opt}')" style="flex:1;text-align:center;padding:8px 4px;border-radius:10px;background:${btnMapping[key]===opt?optColors[opt]:'rgba(255,255,255,.08)'};border:1px solid ${btnMapping[key]===opt?'transparent':'rgba(255,255,255,.1)'};cursor:pointer;font-size:11px;font-weight:700;color:${btnMapping[key]===opt?'#fff':'rgba(235,235,245,.6)'}">${optLabels[opt]}</div>`).join('')}
+        ${opts.map(opt=>`<div onclick="setBtnMapping('${key}','${opt}')" style="flex:1;text-align:center;padding:8px 4px;border-radius:10px;background:${btnMapping[key]===opt?optColors[opt]:'rgba(255,255,255,.08)'};border:1px solid ${btnMapping[key]===opt?'transparent':'rgba(255,255,255,.1)'};cursor:pointer;font-size:11px;font-weight:700;color:${btnMapping[key]===opt?'#fff':'rgba(235,235,245,.6)'};display:flex;align-items:center;justify-content:center">${optLabels[opt]}</div>`).join('')}
       </div>
     </div>`).join('');
 }
@@ -1981,7 +2007,8 @@ function confirmEndGame(){
   ]);
 }
 function endGame(){
-  if(state.currentGame)collectSummaryData();
+  const sumActive=document.querySelector('#screen-summary.active');
+  if(state.currentGame&&sumActive)collectSummaryData();
   const g=state.currentGame;if(!g)return;
   g.endedAt=new Date().toISOString();
   if(!state.games)state.games=[];
@@ -2001,10 +2028,13 @@ function closeGameToHistory(){
 // ── History ──
 function renderHistoryScoreboard(g){
   const runs=g.inningRuns||[];
-  if(!runs.length)return`<div class="score-pill"><div class="score-pill-team"><div class="score-pill-name">${g.awayTeam}</div><div class="score-pill-num">${g.awayScore}</div></div><div class="score-pill-dash">—</div><div class="score-pill-team"><div class="score-pill-name">${g.homeTeam}</div><div class="score-pill-num">${g.homeScore}</div></div></div>`;
+  const maxInn=Math.max(g.inning||1,runs.length,1);
   let h='<div class="hist-scoreboard"><div class="hist-sb-col lbl"><div class="hist-sb-hdr"></div><div class="hist-sb-cell" style="color:var(--t3);font-size:9px">'+g.awayTeam.substring(0,3).toUpperCase()+'</div><div class="hist-sb-cell" style="color:var(--t3);font-size:9px">'+g.homeTeam.substring(0,3).toUpperCase()+'</div></div>';
-  for(let i=0;i<runs.length;i++){
-    h+=`<div class="hist-sb-col"><div class="hist-sb-hdr">${i+1}</div><div class="hist-sb-cell">${runs[i].top||0}</div><div class="hist-sb-cell">${runs[i].bot||0}</div></div>`;
+  for(let i=0;i<maxInn;i++){
+    const r=runs[i]||{top:0,bot:0};
+    const topVal=r.top||0;
+    const botVal=i<maxInn-1||g.endedAt?r.bot||0:(r.bot||'—');
+    h+=`<div class="hist-sb-col"><div class="hist-sb-hdr">${i+1}</div><div class="hist-sb-cell">${topVal}</div><div class="hist-sb-cell">${botVal}</div></div>`;
   }
   h+='<div class="hist-sb-col lbl" style="border-left:1px solid var(--sep);padding-left:3px;margin-left:2px"><div class="hist-sb-hdr">R</div><div class="hist-sb-cell total">'+g.awayScore+'</div><div class="hist-sb-cell total">'+g.homeScore+'</div></div></div>';
   return h;
@@ -2015,8 +2045,12 @@ function renderHistory(){
     c.innerHTML=`<div style="text-align:center;padding:2rem 1rem"><div style="font-size:15px;font-weight:600;color:var(--text);margin-bottom:8px">No games yet</div><div style="font-size:13px;color:var(--t2);line-height:1.6">Tap <strong>+ New Game</strong> to get started.<br>Check <strong>Configuration</strong> for your league's pitch limits.</div></div>`;
     return;
   }
+  let firstCompletedFound=false;
   c.innerHTML=state.games.map((g,gi)=>{
     const live=!g.endedAt;
+    const isFirstCompleted=!live&&!firstCompletedFound;
+    if(isFirstCompleted)firstCompletedFound=true;
+    const expanded=live||isFirstCompleted;
     const getRestPitchers=pitchers=>pitchers.filter(p=>p.pitches>0).map(p=>{
       const cfg=state.configs.find(c=>c.id===g.configId);
       const thr=(cfg?.thresholds||DEFAULT_THRESHOLDS).slice().sort((a,b)=>a.pitches-b.pitches);
@@ -2029,6 +2063,7 @@ function renderHistory(){
     const modeBg=g.mode==='advanced'?'var(--blue-bg)':'var(--bg)';
     const modeColor=g.mode==='advanced'?'var(--blue)':'var(--t2)';
     const modeTxt=g.mode==='advanced'?'Advanced':'Simple';
+    const detailId='hist-detail-'+gi;
     return`<div class="swipe-card-wrap">
       <div class="swipe-card-bg"><button onclick="confirmDelGame(${gi})" style="background:transparent;border:none;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:3px;padding:6px"><svg width="24" height="24" viewBox="0 0 22 22" fill="none"><path d="M7 5V4a1.5 1.5 0 0 1 1.5-1.5h5A1.5 1.5 0 0 1 15 4v1M3 5h16M17 5l-1.3 13.04A2 2 0 0 1 13.71 20H8.29a2 2 0 0 1-1.99-1.96L5 5" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span style="font-size:10px;font-weight:700;color:#fff">Delete</span></button></div>
       <div class="swipe-card-inner hist-card">
@@ -2043,20 +2078,29 @@ function renderHistory(){
           </div>
           ${renderHistoryScoreboard(g)}
         </div>
+        <div id="${detailId}" style="display:${expanded?'block':'none'}">
         ${allRest.length?`<div class="rest-section"><div class="rest-section-lbl">Rest required</div>${allRest.map(r=>`<div class="rest-row"><div class="rest-name">${r.name}${r.num?' <span style="color:var(--t3)">#'+r.num+'</span>':''} <span class="rest-sub">· ${r.pitches} pitches</span></div><div class="rest-chip" style="background:${r.days>=2?'var(--red-bg)':'var(--amber-bg)'};color:${r.days>=2?'var(--red)':'var(--amber)'}">${r.days}d rest</div></div>`).join('')}</div>`:''}
         <div class="hist-card-actions">
           ${live?`<div class="hist-action-btn primary" onclick="resumeGame(${gi})">Resume</div>`:`<div class="hist-action-btn secondary" onclick="openSavedStats(${gi})">View stats</div><div class="hist-action-btn secondary" onclick="openExportForGame(${gi})">Summary</div>`}
         </div>
+        </div>
+        ${!expanded?`<div class="hist-card-actions"><div class="hist-action-btn secondary" onclick="toggleHistCard('${detailId}',this)">Show details</div></div>`:''}
       </div>
     </div>`;
   }).join('');
   requestAnimationFrame(()=>initSwipe());
 }
+function toggleHistCard(id,btn){
+  const el=document.getElementById(id);if(!el)return;
+  const show=el.style.display==='none';
+  el.style.display=show?'block':'none';
+  btn.textContent=show?'Hide details':'Show details';
+}
 function goSetup(){initSetup();showScreen('setup');}
 function resumeGame(gi){
   const g=state.games[gi];state.currentGame=g;state.games.splice(gi,1);
   const cfg=state.configs.find(c=>c.id===g.configId);
-  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;}
+  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
   saveState();renderGame();showScreen('game');
 }
 function confirmDelGame(i){
@@ -2099,6 +2143,8 @@ function closeOtherCards(except){document.querySelectorAll('.swipe-card-inner').
 // ── Summary / Export ──
 function initSummary(){
   const g=state.currentGame||state._expGame;if(!g)return;
+  const cfg=state.configs.find(c=>c.id===g.configId);
+  document.getElementById('sum-division').value=g.division||(cfg?cfg.name:'')||'';
   document.getElementById('sum-hr-hl').textContent=`${g.homeTeam} HRs`;
   document.getElementById('sum-hr-al').textContent=`${g.awayTeam} HRs`;
   document.getElementById('sum-hr-home').value=g.hrHome||'';
@@ -2184,6 +2230,7 @@ function saveSummaryFromHistory(){
 }
 function collectSummaryData(){
   const g=state.currentGame||state._expGame;if(!g)return;
+  g.division=document.getElementById('sum-division')?.value.trim()||'';
   g.hrHome=document.getElementById('sum-hr-home')?.value||'';
   g.hrAway=document.getElementById('sum-hr-away')?.value||'';
   g.umpPlateName=document.getElementById('sum-pu-name')?.value||'';
@@ -2218,7 +2265,8 @@ function buildSummaryText(){
   };
   const totalInnings=g.inning?(g.isTop?g.inning-1:g.inning):0;
   const endTimeStr=g.endedAt?new Date(g.endedAt).toLocaleTimeString([],{hour:'numeric',minute:'2-digit'}):'';
-  let txt=`Game Summary\n${'─'.repeat(8)}\n${g.homeTeam} vs ${g.awayTeam}\n${g.date}${g.time?' · '+g.time:''}${endTimeStr?' – '+endTimeStr:''}${g.field?' · '+g.field:''}\n${totalInnings} inning${totalInnings!==1?'s':''}\nFinal: ${g.homeTeam} ${g.homeScore} – ${g.awayTeam} ${g.awayScore}\n\nPitchers\n${'─'.repeat(8)}\n${pitcherLines('home')}\n${pitcherLines('away')}\n\nCatchers\n${'─'.repeat(8)}\n${catcherLines('home')}\n${catcherLines('away')}`;
+  const div=g.division||'';
+  let txt=`Game Summary\n${'─'.repeat(8)}\n${div?div+'\n':''}${g.homeTeam} vs ${g.awayTeam}\n${g.date}${g.time?' · '+g.time:''}${endTimeStr?' – '+endTimeStr:''}${g.field?' · '+g.field:''}\n${totalInnings} inning${totalInnings!==1?'s':''}\nFinal: ${g.homeTeam} ${g.homeScore} – ${g.awayTeam} ${g.awayScore}\n\nPitchers\n${'─'.repeat(8)}\n${pitcherLines('home')}\n${pitcherLines('away')}\n\nCatchers\n${'─'.repeat(8)}\n${catcherLines('home')}\n${catcherLines('away')}`;
   txt+=`\n\nHome Runs\n${'─'.repeat(8)}\n${g.homeTeam}: ${g.hrHome||'None'}\n${g.awayTeam}: ${g.hrAway||'None'}`;
   txt+=`\n\nUmpires\n${'─'.repeat(8)}\nPlate: ${g.umpPlateName||'—'} (Feedback: ${g.umpPlateIssue==='Yes'?'Yes':'None'})${g.umpPlateComments?' — '+g.umpPlateComments:''}`;
   txt+=`\nBase: ${g.umpBaseName||'—'} (Feedback: ${g.umpBaseIssue==='Yes'?'Yes':'None'})${g.umpBaseComments?' — '+g.umpBaseComments:''}`;
@@ -2233,7 +2281,8 @@ function copyExportModal(btn){
 function emailExportModal(){
   const g=state.currentGame||state._expGame;
   const txt=window._exportTxt||window._histExportTxt||'';
-  const s=encodeURIComponent(`Pitch Count — ${g?.homeTeam||''} vs ${g?.awayTeam||''} — ${g?.date||''}`);
+  const divPfx=g?.division?g.division+' — ':'';
+  const s=encodeURIComponent(`${divPfx}Pitch Count — ${g?.homeTeam||''} vs ${g?.awayTeam||''} — ${g?.date||''}`);
   const a=document.createElement('a');a.href=`mailto:?subject=${s}&body=${encodeURIComponent(txt)}`;a.style.display='none';document.body.appendChild(a);a.click();setTimeout(()=>document.body.removeChild(a),500);
 }
 function openSavedStats(gi){
@@ -2306,7 +2355,7 @@ function renderConfigScreen(){
   const list=document.getElementById('config-list');
   list.innerHTML=state.configs.map(cfg=>`
     <div class="config-item">
-      <div style="flex:1;min-width:0"><div class="config-name">${cfg.name}${cfg.isDefault?'<span class="default-badge">Default</span>':''}</div><div class="config-sub">Max ${cfg.pitchMax} pitches · ${cfg.catcherInnMax} catcher inn.${cfg.mercyRuns?' · '+cfg.mercyRuns+'-run mercy':''}${cfg.pitchCatchLim?' · no catch @'+cfg.pitchCatchLim+'p':''}</div></div>
+      <div style="flex:1;min-width:0"><div class="config-name">${cfg.name}${cfg.isDefault?'<span class="default-badge">Default</span>':''}</div><div class="config-sub">Max ${cfg.pitchMax} pitches · ${cfg.maxInnings||9} inn. · ${cfg.catcherInnMax} catcher inn.${cfg.mercyRuns?' · '+cfg.mercyRuns+'-run mercy':''}${cfg.mercyGame?' · '+cfg.mercyGame+'-run game mercy':''}${cfg.pitchCatchLim?' · no catch @'+cfg.pitchCatchLim+'p':''}</div></div>
       <div class="config-actions">
         ${!cfg.isDefault?`<div class="btn-xs" onclick="setDefaultConfig('${cfg.id}')">Set default</div>`:''}
         <div class="btn-xs" onclick="showConfigForm('${cfg.id}')">Edit</div>
@@ -2328,7 +2377,7 @@ function showConfigForm(id){
   const ov=document.createElement('div');ov.className='modal-overlay';ov.id='active-modal';
   ov.addEventListener('click',e=>{if(e.target===ov)closeModal();});
   const thrRows=thr.map((t,i)=>`<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:7px;align-items:end;margin-bottom:8px"><div><div class="lbl">Threshold ${i+1} (pitches)</div><input type="number" id="thr-p-${i}" value="${t.pitches}" min="1" max="200"></div><div><div class="lbl">Days rest</div><input type="number" id="thr-d-${i}" value="${t.days}" min="0" max="10"></div><div class="trash-btn" onclick="this.closest('div[style]').remove()"><svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M5 3V2a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v1M2 3h11M13 3l-.867 9.356A2 2 0 0 1 10.14 14H4.86a2 2 0 0 1-1.993-1.644L2 3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg></div></div>`).join('');
-  ov.innerHTML=`<div class="modal-box"><button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M1 1l12 12M13 1L1 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><div class="modal-title">${existing?'Edit':'New'} Configuration</div><div style="margin-bottom:10px"><div class="lbl">Name</div><input type="text" id="cfg-name" value="${existing?existing.name:''}" placeholder="e.g. Minors 7-10"></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Max pitches</div><input type="number" id="cfg-pitch" value="${existing?existing.pitchMax:50}" min="1" max="200"></div><div><div class="lbl">Catcher inn. max</div><input type="number" id="cfg-catch" value="${existing?existing.catcherInnMax:4}" min="1" max="9"></div></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Mercy runs / half inning</div><input type="number" id="cfg-mercy" value="${existing?existing.mercyRuns||0:5}" min="0" max="99" placeholder="0 = off"></div><div><div class="lbl">Pitcher can't catch after</div><input type="number" id="cfg-pcatch" value="${existing?existing.pitchCatchLim||0:41}" min="0" max="200" placeholder="0 = off"></div></div><div class="lbl" style="margin-bottom:8px">Rest thresholds</div><div id="thr-rows">${thrRows}</div><div class="btn-sm" onclick="addThrRow()" style="margin-bottom:14px;display:inline-flex">+ Add threshold</div><div class="modal-actions"><div class="modal-btn" onclick="closeModal()">Cancel</div><div class="modal-btn primary" onclick="saveConfigForm('${id||''}')">Save</div></div></div>`;
+  ov.innerHTML=`<div class="modal-box"><button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M1 1l12 12M13 1L1 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><div class="modal-title">${existing?'Edit':'New'} Configuration</div><div style="margin-bottom:10px"><div class="lbl">Division name</div><input type="text" id="cfg-name" value="${existing?existing.name:''}" placeholder="e.g. Minors 8 or AA"></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Max pitches</div><input type="number" id="cfg-pitch" value="${existing?existing.pitchMax:50}" min="1" max="200"></div><div><div class="lbl">Catcher inn. max</div><input type="number" id="cfg-catch" value="${existing?existing.catcherInnMax:4}" min="1" max="9"></div></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Max innings</div><input type="number" id="cfg-maxinn" value="${existing?existing.maxInnings||'':6}" min="1" max="20" placeholder="Empty = 9"></div><div><div class="lbl">Pitcher can't catch after</div><input type="number" id="cfg-pcatch" value="${existing?existing.pitchCatchLim||0:41}" min="0" max="200" placeholder="0 = off"></div></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Mercy runs / half inning</div><input type="number" id="cfg-mercy" value="${existing?existing.mercyRuns||0:5}" min="0" max="99" placeholder="0 = off"></div><div><div class="lbl">Mercy runs / full game</div><input type="number" id="cfg-mercygame" value="${existing?.mercyGame||''}" min="0" max="99" placeholder="Empty = off"></div></div><div class="lbl" style="margin-bottom:8px">Rest thresholds</div><div id="thr-rows">${thrRows}</div><div class="btn-sm" onclick="addThrRow()" style="margin-bottom:14px;display:inline-flex">+ Add threshold</div><div class="modal-actions"><div class="modal-btn" onclick="closeModal()">Cancel</div><div class="modal-btn primary" onclick="saveConfigForm('${id||''}')">Save</div></div></div>`;
   document.body.appendChild(ov);
 }
 function addThrRow(){
@@ -2343,14 +2392,16 @@ function saveConfigForm(id){
   const catcherInnMax=parseInt(document.getElementById('cfg-catch').value)||4;
   const mercyRuns=parseInt(document.getElementById('cfg-mercy').value)||0;
   const pitchCatchLim=parseInt(document.getElementById('cfg-pcatch').value)||0;
+  const mercyGame=parseInt(document.getElementById('cfg-mercygame').value)||0;
+  const maxInnings=parseInt(document.getElementById('cfg-maxinn').value)||0;
   const thresholds=[];
   document.getElementById('thr-rows').querySelectorAll('[id^="thr-p-"]').forEach((el,i)=>{
     const pitches=parseInt(el.value);const days=parseInt(document.getElementById('thr-d-'+i)?.value)||0;
     if(pitches>0)thresholds.push({pitches,days});
   });
   thresholds.sort((a,b)=>a.pitches-b.pitches);
-  if(id){const cfg=state.configs.find(c=>c.id===id);if(cfg){cfg.name=name;cfg.pitchMax=pitchMax;cfg.catcherInnMax=catcherInnMax;cfg.mercyRuns=mercyRuns;cfg.pitchCatchLim=pitchCatchLim;cfg.thresholds=thresholds;}}
-  else state.configs.push({id:'cfg_'+Date.now(),name,pitchMax,catcherInnMax,mercyRuns,pitchCatchLim,thresholds,isDefault:state.configs.length===0});
+  if(id){const cfg=state.configs.find(c=>c.id===id);if(cfg){cfg.name=name;cfg.pitchMax=pitchMax;cfg.catcherInnMax=catcherInnMax;cfg.mercyRuns=mercyRuns;cfg.pitchCatchLim=pitchCatchLim;cfg.mercyGame=mercyGame;cfg.maxInnings=maxInnings;cfg.thresholds=thresholds;}}
+  else state.configs.push({id:'cfg_'+Date.now(),name,pitchMax,catcherInnMax,mercyRuns,pitchCatchLim,mercyGame,maxInnings,thresholds,isDefault:state.configs.length===0});
   applyActiveConfig();saveState();closeModal();renderConfigScreen();
 }
 function setDefaultConfig(id){state.configs.forEach(c=>c.isDefault=(c.id===id));state.activeConfigId=id;applyActiveConfig();saveState();renderConfigScreen();}

--- a/app/index.html
+++ b/app/index.html
@@ -99,7 +99,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 .inn-scoreboard::-webkit-scrollbar{display:none}
 .inn-sb-col{display:flex;flex-direction:column;align-items:center;min-width:24px;flex-shrink:0}
 .inn-sb-col.lbl{min-width:32px;align-items:flex-start}
-.inn-sb-hdr{font-size:9px;font-weight:700;color:rgba(235,235,245,.35);letter-spacing:.3px;padding:0 2px 2px;text-transform:uppercase;height:15px;display:flex;align-items:flex-end}
+.inn-sb-hdr{font-size:9px;font-weight:700;color:rgba(235,235,245,.35);letter-spacing:.3px;padding:0 2px 2px;text-transform:uppercase;height:15px;display:flex;align-items:flex-end;justify-content:center}
 .inn-sb-cell{font-size:11px;font-weight:600;color:rgba(255,255,255,.7);padding:1px 2px;text-align:center;min-width:24px;line-height:15px;height:17px;display:flex;align-items:center;justify-content:center}
 .inn-sb-cell.current{color:#fff;font-weight:800}
 .inn-sb-cell.total{color:#fff;font-weight:800;font-size:12px}
@@ -355,7 +355,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 .hist-scoreboard::-webkit-scrollbar{display:none}
 .hist-sb-col{display:flex;flex-direction:column;align-items:center;min-width:20px;flex-shrink:0}
 .hist-sb-col.lbl{min-width:28px;align-items:flex-start}
-.hist-sb-hdr{font-size:8px;font-weight:700;color:var(--t3);letter-spacing:.3px;text-transform:uppercase;height:14px;display:flex;align-items:flex-end}
+.hist-sb-hdr{font-size:8px;font-weight:700;color:var(--t3);letter-spacing:.3px;text-transform:uppercase;height:14px;display:flex;align-items:flex-end;justify-content:center}
 .hist-sb-cell{font-size:10px;font-weight:600;color:var(--text);padding:1px 2px;text-align:center;min-width:20px;line-height:14px;height:16px;display:flex;align-items:center;justify-content:center}
 .hist-sb-cell.total{font-weight:800;font-size:11px}
 .rest-section{border-top:1px solid var(--sep);padding:10px 16px}
@@ -739,6 +739,13 @@ textarea{resize:vertical;min-height:56px}
     <div style="width:70px"></div>
   </div>
   <div class="summary-content">
+    <!-- Division -->
+    <div>
+      <div class="section-header-lbl">Division</div>
+      <div class="form-card">
+        <div class="form-row" style="border-bottom:none"><div class="form-row-lbl">Division</div><input class="form-input" id="sum-division" placeholder="e.g. Minors 8 or AA" autocapitalize="words"></div>
+      </div>
+    </div>
     <!-- HR fields -->
     <div>
       <div class="section-header-lbl">Home Runs</div>
@@ -916,7 +923,7 @@ const PT_TYPES = {
   BIP:{label:'<svg width="12" height="12" viewBox="0 0 496.926 496.926" fill="currentColor" style="vertical-align:-1px"><path d="M227.831,233.153c-17.891,32.025-36.395,65.14-44.667,77.982c-6.072,9.438-28.018,41.875-98.063,142.75c-5.737-1.33-11.915,1.004-15.673,6.473c-2.228,3.242-3.05,7.145-2.333,11.008c0.717,3.854,2.907,7.199,6.139,9.428l19.699,13.541c2.467,1.691,5.345,2.592,8.329,2.592h0.01c4.838,0,9.362-2.383,12.431-6.848c3.471-5.049,3.347-11.59,0.115-16.467c13.091-19.258,83.299-122.496,98.13-142.711c9.018-12.316,33.287-41.424,56.744-69.566c19.298-23.151,37.514-45.021,46.244-56.314c19.106-24.729,50.213-66.909,50.624-67.454l58.379-84.943c11.839-17.222,3.979-30.208-2.036-34.817L400.052,2.792C399.583,2.505,395.299,0,389.188,0c-5.871,0-14.487,2.343-22.156,13.512L308.558,98.58c-0.277,0.44-28.506,44.6-44.753,71.298C256.375,182.061,242.51,206.875,227.831,233.153z"/></svg>',  name:'In Play',     color:'#34C759',bg:'#E8F9ED'},
 };
 const DEFAULT_THRESHOLDS=[{pitches:20,days:0},{pitches:35,days:1},{pitches:50,days:2}];
-let PITCH_MAX=50, C_INN_LIM=4, PITCH_C_LIM=41, MERCY_RUNS=0;
+let PITCH_MAX=50, C_INN_LIM=4, PITCH_C_LIM=41, MERCY_RUNS=0, MERCY_GAME=0, MAX_INN=6;
 const BATTER_WARN=6, BATTER_CRIT=9;
 let selectedMode='simple'; // for setup
 
@@ -928,7 +935,7 @@ function loadState(){
   if(!state.configs)state.configs=[];
   if(!state.fields)state.fields=[];
   if(!state.configs.length){
-    state.configs.push({id:'default',name:'Default Minors 7-10',pitchMax:50,catcherInnMax:4,mercyRuns:5,pitchCatchLim:41,isDefault:true,thresholds:JSON.parse(JSON.stringify(DEFAULT_THRESHOLDS))});
+    state.configs.push({id:'default',name:'Default Minors 7-10',pitchMax:50,catcherInnMax:4,mercyRuns:5,pitchCatchLim:41,mercyGame:0,maxInnings:6,isDefault:true,thresholds:JSON.parse(JSON.stringify(DEFAULT_THRESHOLDS))});
     state.activeConfigId='default';
   }
   state.configs.forEach(c=>{if(!c.thresholds)c.thresholds=JSON.parse(JSON.stringify(DEFAULT_THRESHOLDS));});
@@ -943,7 +950,7 @@ function saveState(){try{localStorage.setItem('spc_v1',JSON.stringify(state));}c
 function saveBtnMapping(){const g=state.currentGame;const mode=g?g.mode:'simple';try{localStorage.setItem('spc_btnmap_'+mode,JSON.stringify(btnMapping));}catch(e){}}
 function applyActiveConfig(){
   const cfg=state.configs.find(c=>c.id===state.activeConfigId)||state.configs[0];
-  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;}
+  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
 }
 
 // ── Navigation ──
@@ -1142,7 +1149,18 @@ function adjScore(side,d){
   haptic('selection');saveState();renderGame();
   if(d>0&&MERCY_RUNS>0&&g.halfInningRuns>=MERCY_RUNS){
     confirmMercyEnd();
+  }else if(d>0&&MERCY_GAME>0&&Math.abs(g.homeScore-g.awayScore)>=MERCY_GAME){
+    confirmMercyGameEnd();
   }
+}
+function confirmMercyGameEnd(){
+  const g=state.currentGame;if(!g)return;
+  const diff=Math.abs(g.homeScore-g.awayScore);
+  const leader=g.homeScore>g.awayScore?g.homeTeam:g.awayTeam;
+  showModal('Game mercy reached',`${leader} leads by ${diff} runs — ${MERCY_GAME}-run game mercy limit reached.`,[
+    {label:'Continue',fn:'closeModal()'},
+    {label:'End game',fn:'closeModal();confirmEndGame()',cls:'red'},
+  ]);
 }
 function confirmMercyEnd(){
   const g=state.currentGame;if(!g)return;
@@ -1167,8 +1185,8 @@ function recordNonPitchOut(){
 }
 
 // ── Half inning ──
-function endHalfInning(){
-  pushSnap();
+function endHalfInning(skipSnap){
+  if(!skipSnap)pushSnap();
   const g=state.currentGame;
   const ap=activePitcher();
   if(ap&&ap.currentBatterPitches>0){ap.batterBreaks.push(ap.currentBatterPitches);ap.lastBatterPitches=ap.currentBatterPitches;ap.currentBatterPitches=0;}
@@ -1186,7 +1204,8 @@ function endHalfInning(){
   g.balls=0;g.strikes=0;g.outs=0;g.atBatLog=[];g.halfInningRuns=0;
   g.pSelectOpen=false;g.cSelectOpen=false;
   haptic('success');saveState();renderGame();window.scrollTo(0,0);
-  if(g.inning>9&&g.isTop&&g.homeScore!==g.awayScore){
+  const innLimit=MAX_INN||9;
+  if(g.inning>innLimit&&g.isTop&&g.homeScore!==g.awayScore){
     showModal('Game complete',`${g.inning-1} innings played. ${g.homeScore>g.awayScore?g.homeTeam:g.awayTeam} wins ${Math.max(g.homeScore,g.awayScore)}–${Math.min(g.homeScore,g.awayScore)}.`,[
       {label:'Continue playing',fn:'closeModal()'},
       {label:'End game',fn:'closeModal();confirmEndGame()',cls:'red'},
@@ -1271,7 +1290,7 @@ function confirmSideRetired(){
   const g=state.currentGame;if(!g)return;
   showModal('End half inning?',`3 outs recorded — end the ${g.isTop?'Top':'Bottom'} of Inning ${g.inning}?`,[
     {label:'Undo',fn:'closeModal();undoLast()'},
-    {label:'End',fn:'closeModal();setTimeout(endHalfInning,50)',cls:'amber'},
+    {label:'End',fn:'closeModal();setTimeout(()=>endHalfInning(true),50)',cls:'amber'},
   ]);
 }
 function doNextBatter(){
@@ -1349,7 +1368,7 @@ function editInningCell(innIdx,half){
 function renderGame(){
   const g=state.currentGame;if(!g)return;
   const cfg=state.configs.find(c=>c.id===g.configId);
-  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;}
+  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
   // Scoreboard
   document.getElementById('sb-home-name').textContent=g.homeTeam;
   document.getElementById('sb-away-name').textContent=g.awayTeam;
@@ -1484,6 +1503,7 @@ function addNewPitcherMidGame(){
   const n=document.getElementById('new-p-name')?.value.trim();if(!n){alert('Enter pitcher name.');return;}
   const nu=document.getElementById('new-p-num')?.value.trim()||'';
   fRoster().pitchers.push(mkPitcher(n,nu));
+  setPI(fRoster().pitchers.length-1);
   saveState();renderGame();
 }
 
@@ -1553,11 +1573,17 @@ function pitchAlerts(p){
 }
 function mercyAlerts(){
   const a=[];
-  if(!MERCY_RUNS||MERCY_RUNS<=0)return a;
   const g=state.currentGame;if(!g)return a;
-  const runs=g.halfInningRuns||0;
-  if(runs>=MERCY_RUNS)a.push({t:'danger',m:`${runs} runs scored this half inning — ${MERCY_RUNS}-run mercy limit reached.`});
-  else if(runs>=MERCY_RUNS-1)a.push({t:'warn',m:`${runs} runs scored — 1 away from ${MERCY_RUNS}-run mercy limit.`});
+  if(MERCY_RUNS>0){
+    const runs=g.halfInningRuns||0;
+    if(runs>=MERCY_RUNS)a.push({t:'danger',m:`${runs} runs scored this half inning — ${MERCY_RUNS}-run mercy limit reached.`});
+    else if(runs>=MERCY_RUNS-1)a.push({t:'warn',m:`${runs} runs scored — 1 away from ${MERCY_RUNS}-run mercy limit.`});
+  }
+  if(MERCY_GAME>0){
+    const diff=Math.abs(g.homeScore-g.awayScore);
+    if(diff>=MERCY_GAME)a.push({t:'danger',m:`Run differential is ${diff} — ${MERCY_GAME}-run game mercy limit reached.`});
+    else if(diff>=MERCY_GAME-1&&diff>0)a.push({t:'warn',m:`Run differential is ${diff} — 1 away from ${MERCY_GAME}-run game mercy limit.`});
+  }
   return a;
 }
 
@@ -1821,7 +1847,7 @@ function getBtnRows(){
       <div style="font-size:12px;font-weight:700;color:rgba(235,235,245,.6);text-transform:uppercase;letter-spacing:.6px;margin-bottom:2px">${label}</div>
       <div style="font-size:11px;color:rgba(235,235,245,.35);margin-bottom:8px">${sub}</div>
       <div style="display:flex;gap:6px">
-        ${opts.map(opt=>`<div onclick="setBtnMapping('${key}','${opt}')" style="flex:1;text-align:center;padding:8px 4px;border-radius:10px;background:${btnMapping[key]===opt?optColors[opt]:'rgba(255,255,255,.08)'};border:1px solid ${btnMapping[key]===opt?'transparent':'rgba(255,255,255,.1)'};cursor:pointer;font-size:11px;font-weight:700;color:${btnMapping[key]===opt?'#fff':'rgba(235,235,245,.6)'}">${optLabels[opt]}</div>`).join('')}
+        ${opts.map(opt=>`<div onclick="setBtnMapping('${key}','${opt}')" style="flex:1;text-align:center;padding:8px 4px;border-radius:10px;background:${btnMapping[key]===opt?optColors[opt]:'rgba(255,255,255,.08)'};border:1px solid ${btnMapping[key]===opt?'transparent':'rgba(255,255,255,.1)'};cursor:pointer;font-size:11px;font-weight:700;color:${btnMapping[key]===opt?'#fff':'rgba(235,235,245,.6)'};display:flex;align-items:center;justify-content:center">${optLabels[opt]}</div>`).join('')}
       </div>
     </div>`).join('');
 }
@@ -1981,7 +2007,8 @@ function confirmEndGame(){
   ]);
 }
 function endGame(){
-  if(state.currentGame)collectSummaryData();
+  const sumActive=document.querySelector('#screen-summary.active');
+  if(state.currentGame&&sumActive)collectSummaryData();
   const g=state.currentGame;if(!g)return;
   g.endedAt=new Date().toISOString();
   if(!state.games)state.games=[];
@@ -2001,10 +2028,13 @@ function closeGameToHistory(){
 // ── History ──
 function renderHistoryScoreboard(g){
   const runs=g.inningRuns||[];
-  if(!runs.length)return`<div class="score-pill"><div class="score-pill-team"><div class="score-pill-name">${g.awayTeam}</div><div class="score-pill-num">${g.awayScore}</div></div><div class="score-pill-dash">—</div><div class="score-pill-team"><div class="score-pill-name">${g.homeTeam}</div><div class="score-pill-num">${g.homeScore}</div></div></div>`;
+  const maxInn=Math.max(g.inning||1,runs.length,1);
   let h='<div class="hist-scoreboard"><div class="hist-sb-col lbl"><div class="hist-sb-hdr"></div><div class="hist-sb-cell" style="color:var(--t3);font-size:9px">'+g.awayTeam.substring(0,3).toUpperCase()+'</div><div class="hist-sb-cell" style="color:var(--t3);font-size:9px">'+g.homeTeam.substring(0,3).toUpperCase()+'</div></div>';
-  for(let i=0;i<runs.length;i++){
-    h+=`<div class="hist-sb-col"><div class="hist-sb-hdr">${i+1}</div><div class="hist-sb-cell">${runs[i].top||0}</div><div class="hist-sb-cell">${runs[i].bot||0}</div></div>`;
+  for(let i=0;i<maxInn;i++){
+    const r=runs[i]||{top:0,bot:0};
+    const topVal=r.top||0;
+    const botVal=i<maxInn-1||g.endedAt?r.bot||0:(r.bot||'—');
+    h+=`<div class="hist-sb-col"><div class="hist-sb-hdr">${i+1}</div><div class="hist-sb-cell">${topVal}</div><div class="hist-sb-cell">${botVal}</div></div>`;
   }
   h+='<div class="hist-sb-col lbl" style="border-left:1px solid var(--sep);padding-left:3px;margin-left:2px"><div class="hist-sb-hdr">R</div><div class="hist-sb-cell total">'+g.awayScore+'</div><div class="hist-sb-cell total">'+g.homeScore+'</div></div></div>';
   return h;
@@ -2015,8 +2045,12 @@ function renderHistory(){
     c.innerHTML=`<div style="text-align:center;padding:2rem 1rem"><div style="font-size:15px;font-weight:600;color:var(--text);margin-bottom:8px">No games yet</div><div style="font-size:13px;color:var(--t2);line-height:1.6">Tap <strong>+ New Game</strong> to get started.<br>Check <strong>Configuration</strong> for your league's pitch limits.</div></div>`;
     return;
   }
+  let firstCompletedFound=false;
   c.innerHTML=state.games.map((g,gi)=>{
     const live=!g.endedAt;
+    const isFirstCompleted=!live&&!firstCompletedFound;
+    if(isFirstCompleted)firstCompletedFound=true;
+    const expanded=live||isFirstCompleted;
     const getRestPitchers=pitchers=>pitchers.filter(p=>p.pitches>0).map(p=>{
       const cfg=state.configs.find(c=>c.id===g.configId);
       const thr=(cfg?.thresholds||DEFAULT_THRESHOLDS).slice().sort((a,b)=>a.pitches-b.pitches);
@@ -2029,6 +2063,7 @@ function renderHistory(){
     const modeBg=g.mode==='advanced'?'var(--blue-bg)':'var(--bg)';
     const modeColor=g.mode==='advanced'?'var(--blue)':'var(--t2)';
     const modeTxt=g.mode==='advanced'?'Advanced':'Simple';
+    const detailId='hist-detail-'+gi;
     return`<div class="swipe-card-wrap">
       <div class="swipe-card-bg"><button onclick="confirmDelGame(${gi})" style="background:transparent;border:none;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:3px;padding:6px"><svg width="24" height="24" viewBox="0 0 22 22" fill="none"><path d="M7 5V4a1.5 1.5 0 0 1 1.5-1.5h5A1.5 1.5 0 0 1 15 4v1M3 5h16M17 5l-1.3 13.04A2 2 0 0 1 13.71 20H8.29a2 2 0 0 1-1.99-1.96L5 5" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span style="font-size:10px;font-weight:700;color:#fff">Delete</span></button></div>
       <div class="swipe-card-inner hist-card">
@@ -2043,20 +2078,29 @@ function renderHistory(){
           </div>
           ${renderHistoryScoreboard(g)}
         </div>
+        <div id="${detailId}" style="display:${expanded?'block':'none'}">
         ${allRest.length?`<div class="rest-section"><div class="rest-section-lbl">Rest required</div>${allRest.map(r=>`<div class="rest-row"><div class="rest-name">${r.name}${r.num?' <span style="color:var(--t3)">#'+r.num+'</span>':''} <span class="rest-sub">· ${r.pitches} pitches</span></div><div class="rest-chip" style="background:${r.days>=2?'var(--red-bg)':'var(--amber-bg)'};color:${r.days>=2?'var(--red)':'var(--amber)'}">${r.days}d rest</div></div>`).join('')}</div>`:''}
         <div class="hist-card-actions">
           ${live?`<div class="hist-action-btn primary" onclick="resumeGame(${gi})">Resume</div>`:`<div class="hist-action-btn secondary" onclick="openSavedStats(${gi})">View stats</div><div class="hist-action-btn secondary" onclick="openExportForGame(${gi})">Summary</div>`}
         </div>
+        </div>
+        ${!expanded?`<div class="hist-card-actions"><div class="hist-action-btn secondary" onclick="toggleHistCard('${detailId}',this)">Show details</div></div>`:''}
       </div>
     </div>`;
   }).join('');
   requestAnimationFrame(()=>initSwipe());
 }
+function toggleHistCard(id,btn){
+  const el=document.getElementById(id);if(!el)return;
+  const show=el.style.display==='none';
+  el.style.display=show?'block':'none';
+  btn.textContent=show?'Hide details':'Show details';
+}
 function goSetup(){initSetup();showScreen('setup');}
 function resumeGame(gi){
   const g=state.games[gi];state.currentGame=g;state.games.splice(gi,1);
   const cfg=state.configs.find(c=>c.id===g.configId);
-  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;}
+  if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
   saveState();renderGame();showScreen('game');
 }
 function confirmDelGame(i){
@@ -2099,6 +2143,8 @@ function closeOtherCards(except){document.querySelectorAll('.swipe-card-inner').
 // ── Summary / Export ──
 function initSummary(){
   const g=state.currentGame||state._expGame;if(!g)return;
+  const cfg=state.configs.find(c=>c.id===g.configId);
+  document.getElementById('sum-division').value=g.division||(cfg?cfg.name:'')||'';
   document.getElementById('sum-hr-hl').textContent=`${g.homeTeam} HRs`;
   document.getElementById('sum-hr-al').textContent=`${g.awayTeam} HRs`;
   document.getElementById('sum-hr-home').value=g.hrHome||'';
@@ -2184,6 +2230,7 @@ function saveSummaryFromHistory(){
 }
 function collectSummaryData(){
   const g=state.currentGame||state._expGame;if(!g)return;
+  g.division=document.getElementById('sum-division')?.value.trim()||'';
   g.hrHome=document.getElementById('sum-hr-home')?.value||'';
   g.hrAway=document.getElementById('sum-hr-away')?.value||'';
   g.umpPlateName=document.getElementById('sum-pu-name')?.value||'';
@@ -2218,7 +2265,8 @@ function buildSummaryText(){
   };
   const totalInnings=g.inning?(g.isTop?g.inning-1:g.inning):0;
   const endTimeStr=g.endedAt?new Date(g.endedAt).toLocaleTimeString([],{hour:'numeric',minute:'2-digit'}):'';
-  let txt=`Game Summary\n${'─'.repeat(8)}\n${g.homeTeam} vs ${g.awayTeam}\n${g.date}${g.time?' · '+g.time:''}${endTimeStr?' – '+endTimeStr:''}${g.field?' · '+g.field:''}\n${totalInnings} inning${totalInnings!==1?'s':''}\nFinal: ${g.homeTeam} ${g.homeScore} – ${g.awayTeam} ${g.awayScore}\n\nPitchers\n${'─'.repeat(8)}\n${pitcherLines('home')}\n${pitcherLines('away')}\n\nCatchers\n${'─'.repeat(8)}\n${catcherLines('home')}\n${catcherLines('away')}`;
+  const div=g.division||'';
+  let txt=`Game Summary\n${'─'.repeat(8)}\n${div?div+'\n':''}${g.homeTeam} vs ${g.awayTeam}\n${g.date}${g.time?' · '+g.time:''}${endTimeStr?' – '+endTimeStr:''}${g.field?' · '+g.field:''}\n${totalInnings} inning${totalInnings!==1?'s':''}\nFinal: ${g.homeTeam} ${g.homeScore} – ${g.awayTeam} ${g.awayScore}\n\nPitchers\n${'─'.repeat(8)}\n${pitcherLines('home')}\n${pitcherLines('away')}\n\nCatchers\n${'─'.repeat(8)}\n${catcherLines('home')}\n${catcherLines('away')}`;
   txt+=`\n\nHome Runs\n${'─'.repeat(8)}\n${g.homeTeam}: ${g.hrHome||'None'}\n${g.awayTeam}: ${g.hrAway||'None'}`;
   txt+=`\n\nUmpires\n${'─'.repeat(8)}\nPlate: ${g.umpPlateName||'—'} (Feedback: ${g.umpPlateIssue==='Yes'?'Yes':'None'})${g.umpPlateComments?' — '+g.umpPlateComments:''}`;
   txt+=`\nBase: ${g.umpBaseName||'—'} (Feedback: ${g.umpBaseIssue==='Yes'?'Yes':'None'})${g.umpBaseComments?' — '+g.umpBaseComments:''}`;
@@ -2233,7 +2281,8 @@ function copyExportModal(btn){
 function emailExportModal(){
   const g=state.currentGame||state._expGame;
   const txt=window._exportTxt||window._histExportTxt||'';
-  const s=encodeURIComponent(`Pitch Count — ${g?.homeTeam||''} vs ${g?.awayTeam||''} — ${g?.date||''}`);
+  const divPfx=g?.division?g.division+' — ':'';
+  const s=encodeURIComponent(`${divPfx}Pitch Count — ${g?.homeTeam||''} vs ${g?.awayTeam||''} — ${g?.date||''}`);
   const a=document.createElement('a');a.href=`mailto:?subject=${s}&body=${encodeURIComponent(txt)}`;a.style.display='none';document.body.appendChild(a);a.click();setTimeout(()=>document.body.removeChild(a),500);
 }
 function openSavedStats(gi){
@@ -2306,7 +2355,7 @@ function renderConfigScreen(){
   const list=document.getElementById('config-list');
   list.innerHTML=state.configs.map(cfg=>`
     <div class="config-item">
-      <div style="flex:1;min-width:0"><div class="config-name">${cfg.name}${cfg.isDefault?'<span class="default-badge">Default</span>':''}</div><div class="config-sub">Max ${cfg.pitchMax} pitches · ${cfg.catcherInnMax} catcher inn.${cfg.mercyRuns?' · '+cfg.mercyRuns+'-run mercy':''}${cfg.pitchCatchLim?' · no catch @'+cfg.pitchCatchLim+'p':''}</div></div>
+      <div style="flex:1;min-width:0"><div class="config-name">${cfg.name}${cfg.isDefault?'<span class="default-badge">Default</span>':''}</div><div class="config-sub">Max ${cfg.pitchMax} pitches · ${cfg.maxInnings||9} inn. · ${cfg.catcherInnMax} catcher inn.${cfg.mercyRuns?' · '+cfg.mercyRuns+'-run mercy':''}${cfg.mercyGame?' · '+cfg.mercyGame+'-run game mercy':''}${cfg.pitchCatchLim?' · no catch @'+cfg.pitchCatchLim+'p':''}</div></div>
       <div class="config-actions">
         ${!cfg.isDefault?`<div class="btn-xs" onclick="setDefaultConfig('${cfg.id}')">Set default</div>`:''}
         <div class="btn-xs" onclick="showConfigForm('${cfg.id}')">Edit</div>
@@ -2328,7 +2377,7 @@ function showConfigForm(id){
   const ov=document.createElement('div');ov.className='modal-overlay';ov.id='active-modal';
   ov.addEventListener('click',e=>{if(e.target===ov)closeModal();});
   const thrRows=thr.map((t,i)=>`<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:7px;align-items:end;margin-bottom:8px"><div><div class="lbl">Threshold ${i+1} (pitches)</div><input type="number" id="thr-p-${i}" value="${t.pitches}" min="1" max="200"></div><div><div class="lbl">Days rest</div><input type="number" id="thr-d-${i}" value="${t.days}" min="0" max="10"></div><div class="trash-btn" onclick="this.closest('div[style]').remove()"><svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M5 3V2a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v1M2 3h11M13 3l-.867 9.356A2 2 0 0 1 10.14 14H4.86a2 2 0 0 1-1.993-1.644L2 3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg></div></div>`).join('');
-  ov.innerHTML=`<div class="modal-box"><button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M1 1l12 12M13 1L1 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><div class="modal-title">${existing?'Edit':'New'} Configuration</div><div style="margin-bottom:10px"><div class="lbl">Name</div><input type="text" id="cfg-name" value="${existing?existing.name:''}" placeholder="e.g. Minors 7-10"></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Max pitches</div><input type="number" id="cfg-pitch" value="${existing?existing.pitchMax:50}" min="1" max="200"></div><div><div class="lbl">Catcher inn. max</div><input type="number" id="cfg-catch" value="${existing?existing.catcherInnMax:4}" min="1" max="9"></div></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Mercy runs / half inning</div><input type="number" id="cfg-mercy" value="${existing?existing.mercyRuns||0:5}" min="0" max="99" placeholder="0 = off"></div><div><div class="lbl">Pitcher can't catch after</div><input type="number" id="cfg-pcatch" value="${existing?existing.pitchCatchLim||0:41}" min="0" max="200" placeholder="0 = off"></div></div><div class="lbl" style="margin-bottom:8px">Rest thresholds</div><div id="thr-rows">${thrRows}</div><div class="btn-sm" onclick="addThrRow()" style="margin-bottom:14px;display:inline-flex">+ Add threshold</div><div class="modal-actions"><div class="modal-btn" onclick="closeModal()">Cancel</div><div class="modal-btn primary" onclick="saveConfigForm('${id||''}')">Save</div></div></div>`;
+  ov.innerHTML=`<div class="modal-box"><button class="modal-close-x" onclick="closeModal()"><svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M1 1l12 12M13 1L1 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><div class="modal-title">${existing?'Edit':'New'} Configuration</div><div style="margin-bottom:10px"><div class="lbl">Division name</div><input type="text" id="cfg-name" value="${existing?existing.name:''}" placeholder="e.g. Minors 8 or AA"></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Max pitches</div><input type="number" id="cfg-pitch" value="${existing?existing.pitchMax:50}" min="1" max="200"></div><div><div class="lbl">Catcher inn. max</div><input type="number" id="cfg-catch" value="${existing?existing.catcherInnMax:4}" min="1" max="9"></div></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Max innings</div><input type="number" id="cfg-maxinn" value="${existing?existing.maxInnings||'':6}" min="1" max="20" placeholder="Empty = 9"></div><div><div class="lbl">Pitcher can't catch after</div><input type="number" id="cfg-pcatch" value="${existing?existing.pitchCatchLim||0:41}" min="0" max="200" placeholder="0 = off"></div></div><div class="row2" style="margin-bottom:12px"><div><div class="lbl">Mercy runs / half inning</div><input type="number" id="cfg-mercy" value="${existing?existing.mercyRuns||0:5}" min="0" max="99" placeholder="0 = off"></div><div><div class="lbl">Mercy runs / full game</div><input type="number" id="cfg-mercygame" value="${existing?.mercyGame||''}" min="0" max="99" placeholder="Empty = off"></div></div><div class="lbl" style="margin-bottom:8px">Rest thresholds</div><div id="thr-rows">${thrRows}</div><div class="btn-sm" onclick="addThrRow()" style="margin-bottom:14px;display:inline-flex">+ Add threshold</div><div class="modal-actions"><div class="modal-btn" onclick="closeModal()">Cancel</div><div class="modal-btn primary" onclick="saveConfigForm('${id||''}')">Save</div></div></div>`;
   document.body.appendChild(ov);
 }
 function addThrRow(){
@@ -2343,14 +2392,16 @@ function saveConfigForm(id){
   const catcherInnMax=parseInt(document.getElementById('cfg-catch').value)||4;
   const mercyRuns=parseInt(document.getElementById('cfg-mercy').value)||0;
   const pitchCatchLim=parseInt(document.getElementById('cfg-pcatch').value)||0;
+  const mercyGame=parseInt(document.getElementById('cfg-mercygame').value)||0;
+  const maxInnings=parseInt(document.getElementById('cfg-maxinn').value)||0;
   const thresholds=[];
   document.getElementById('thr-rows').querySelectorAll('[id^="thr-p-"]').forEach((el,i)=>{
     const pitches=parseInt(el.value);const days=parseInt(document.getElementById('thr-d-'+i)?.value)||0;
     if(pitches>0)thresholds.push({pitches,days});
   });
   thresholds.sort((a,b)=>a.pitches-b.pitches);
-  if(id){const cfg=state.configs.find(c=>c.id===id);if(cfg){cfg.name=name;cfg.pitchMax=pitchMax;cfg.catcherInnMax=catcherInnMax;cfg.mercyRuns=mercyRuns;cfg.pitchCatchLim=pitchCatchLim;cfg.thresholds=thresholds;}}
-  else state.configs.push({id:'cfg_'+Date.now(),name,pitchMax,catcherInnMax,mercyRuns,pitchCatchLim,thresholds,isDefault:state.configs.length===0});
+  if(id){const cfg=state.configs.find(c=>c.id===id);if(cfg){cfg.name=name;cfg.pitchMax=pitchMax;cfg.catcherInnMax=catcherInnMax;cfg.mercyRuns=mercyRuns;cfg.pitchCatchLim=pitchCatchLim;cfg.mercyGame=mercyGame;cfg.maxInnings=maxInnings;cfg.thresholds=thresholds;}}
+  else state.configs.push({id:'cfg_'+Date.now(),name,pitchMax,catcherInnMax,mercyRuns,pitchCatchLim,mercyGame,maxInnings,thresholds,isDefault:state.configs.length===0});
   applyActiveConfig();saveState();closeModal();renderConfigScreen();
 }
 function setDefaultConfig(id){state.configs.forEach(c=>c.isDefault=(c.id===id));state.activeConfigId=id;applyActiveConfig();saveState();renderConfigScreen();}

--- a/tests/v2-features.spec.ts
+++ b/tests/v2-features.spec.ts
@@ -855,4 +855,235 @@ test.describe('Batch fixes (#94-#103)', () => {
     await page.waitForSelector('.modal-overlay', { timeout: 3000 });
     await expect(page.locator('.modal-box')).toContainText('6 innings');
   });
+
+  test('#94: umpire names persist through live game summary visit', async ({ page }) => {
+    await page.click('.new-game-btn');
+    await page.waitForSelector('#screen-setup.active');
+    await page.click('#mode-simple');
+    await page.fill('#s-home', 'Eagles');
+    await page.fill('#s-away', 'Hawks');
+    await page.fill('#hp-name', 'Jake');
+    await page.fill('#ap-name', 'Sam');
+    await page.fill('#s-ump-plate', 'John Smith');
+    await page.fill('#s-ump-base', 'Mike Jones');
+    await page.click('.start-btn');
+    await page.waitForSelector('#screen-game.active');
+    // Visit summary during live game
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'Game summary' }).click();
+    await page.waitForSelector('#screen-summary.active');
+    await expect(page.locator('#sum-pu-name')).toHaveValue('John Smith');
+    await expect(page.locator('#sum-bu-name')).toHaveValue('Mike Jones');
+    // Go back and end game
+    await page.click('text=‹ Back');
+    await page.waitForSelector('#screen-game.active');
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'End game' }).click();
+    await page.locator('.modal-btn.red').click();
+    await page.waitForSelector('#screen-history.active');
+    // Verify umpire names still persist in saved game summary
+    await page.locator('.hist-action-btn', { hasText: 'Summary' }).first().click();
+    await page.waitForSelector('#screen-summary.active');
+    await expect(page.locator('#sum-pu-name')).toHaveValue('John Smith');
+    await expect(page.locator('#sum-bu-name')).toHaveValue('Mike Jones');
+  });
+
+  test('#95: division prefix in email subject', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'Game summary' }).click();
+    await page.waitForSelector('#screen-summary.active');
+    await page.fill('#sum-division', 'Minors 8');
+    await page.click('text=‹ Back');
+    // End game
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'End game' }).click();
+    await page.locator('.modal-btn.red').click();
+    await page.waitForSelector('#screen-history.active');
+    // Open summary and generate export
+    await page.locator('.hist-action-btn', { hasText: 'Summary' }).first().click();
+    await page.waitForSelector('#screen-summary.active');
+    // Save and generate report
+    await page.locator('.summary-action-btn', { hasText: 'Share' }).click();
+    await page.waitForSelector('#active-modal .export-box');
+    // Check export text includes division
+    const exportText = await page.locator('#active-modal .export-box').textContent();
+    expect(exportText).toContain('Minors 8');
+  });
+
+  test('#95: division in export body text', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'Game summary' }).click();
+    await page.waitForSelector('#screen-summary.active');
+    await page.fill('#sum-division', 'Majors');
+    await page.click('text=‹ Back');
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'End game' }).click();
+    await page.locator('.modal-btn.red').click();
+    await page.waitForSelector('#screen-history.active');
+    await page.locator('.hist-action-btn', { hasText: 'Summary' }).first().click();
+    await page.waitForSelector('#screen-summary.active');
+    await page.locator('.summary-action-btn', { hasText: 'Share' }).click();
+    await page.waitForSelector('#active-modal .export-box');
+    const exportText = await page.locator('#active-modal .export-box').textContent();
+    expect(exportText).toContain('Majors');
+  });
+
+  test('#96: live game is always expanded in history', async ({ page }) => {
+    // End a game first so there's a completed game
+    await startGame(page, { mode: 'simple', homeTeam: 'Old', awayTeam: 'Game' });
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'End game' }).click();
+    await page.locator('.modal-btn.red').click();
+    await page.waitForSelector('#screen-history.active');
+    // Start a new game and close to history (live)
+    await startGame(page, { mode: 'simple', homeTeam: 'Live', awayTeam: 'Game' });
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'Close' }).click();
+    await page.waitForSelector('#screen-history.active');
+    // Live game card (index 0) should have Resume visible
+    const liveCard = page.locator('.swipe-card-wrap').first();
+    await expect(liveCard.locator('.hist-action-btn', { hasText: 'Resume' })).toBeVisible();
+  });
+
+  test('#96: Hide details toggle collapses expanded card', async ({ page }) => {
+    // Create 3 completed games
+    for (let i = 0; i < 3; i++) {
+      await startGame(page, { mode: 'simple', homeTeam: `T${i}H`, awayTeam: `T${i}A` });
+      await page.click('.menu-btn');
+      await page.locator('.hbg-item', { hasText: 'End game' }).click();
+      await page.locator('.modal-btn.red').click();
+      await page.waitForSelector('#screen-history.active');
+    }
+    // Expand the third card
+    const thirdCard = page.locator('.swipe-card-wrap').nth(2);
+    await thirdCard.locator('text=Show details').click();
+    await expect(page.locator('#hist-detail-2')).toBeVisible();
+    // Now hide it
+    await thirdCard.locator('text=Hide details').click();
+    await expect(page.locator('#hist-detail-2')).toBeHidden();
+  });
+
+  test('#97: game mercy warning at 1 run away', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).saveState();
+    }).catch(() => {});
+    await page.evaluate(() => {
+      const s = JSON.parse(localStorage.getItem('spc_v1') || '{}');
+      if (!s.configs) s.configs = [];
+      if (s.configs[0]) { s.configs[0].mercyGame = 5; s.configs[0].mercyRuns = 0; }
+      localStorage.setItem('spc_v1', JSON.stringify(s));
+    });
+    await page.reload();
+    await page.waitForSelector('#screen-history.active');
+    await startGame(page, { mode: 'simple' });
+    // Add 4 runs (1 away from 5-run game mercy)
+    for (let i = 0; i < 4; i++) {
+      await page.click('.sb-adj >> nth=1');
+    }
+    // Should see warning alert about game mercy
+    await expect(page.locator('.alert.a-warn')).toContainText('game mercy');
+  });
+
+  test('#97: game mercy Continue dismisses modal', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).saveState();
+    }).catch(() => {});
+    await page.evaluate(() => {
+      const s = JSON.parse(localStorage.getItem('spc_v1') || '{}');
+      if (!s.configs) s.configs = [];
+      if (s.configs[0]) s.configs[0].mercyGame = 3;
+      localStorage.setItem('spc_v1', JSON.stringify(s));
+    });
+    await page.reload();
+    await page.waitForSelector('#screen-history.active');
+    await startGame(page, { mode: 'simple' });
+    for (let i = 0; i < 3; i++) {
+      await page.click('.sb-adj >> nth=1');
+    }
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+    await page.locator('.modal-btn', { hasText: 'Continue' }).click();
+    // Modal should be gone, game continues
+    await expect(page.locator('.modal-overlay')).toHaveCount(0);
+    await expect(page.locator('#screen-game')).toHaveClass(/active/);
+  });
+
+  test('#97: game mercy End game ends the game', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).saveState();
+    }).catch(() => {});
+    await page.evaluate(() => {
+      const s = JSON.parse(localStorage.getItem('spc_v1') || '{}');
+      if (!s.configs) s.configs = [];
+      if (s.configs[0]) s.configs[0].mercyGame = 3;
+      localStorage.setItem('spc_v1', JSON.stringify(s));
+    });
+    await page.reload();
+    await page.waitForSelector('#screen-history.active');
+    await startGame(page, { mode: 'simple' });
+    for (let i = 0; i < 3; i++) {
+      await page.click('.sb-adj >> nth=1');
+    }
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+    // Click End game on mercy modal
+    await page.locator('.modal-btn', { hasText: 'End game' }).click();
+    // Should show confirmEndGame modal
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+    await page.locator('.modal-btn.red', { hasText: 'End now' }).click();
+    await page.waitForSelector('#screen-history.active');
+  });
+
+  test('#98: R column header has centered justify-content', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    const rHeader = page.locator('.inn-sb-hdr', { hasText: 'R' });
+    await expect(rHeader).toHaveCSS('justify-content', 'center');
+  });
+
+  test('#99: tied game at max innings allows extra innings', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    // Play through 6 innings (12 half-innings), score stays 0-0 (tied)
+    for (let i = 0; i < 12; i++) {
+      await page.click('.end-half-btn');
+      await page.click('.modal-btn.amber');
+    }
+    // Should NOT see game complete modal since tied 0-0
+    await page.waitForTimeout(500);
+    await expect(page.locator('.modal-overlay')).toHaveCount(0);
+    // Should be in inning 7
+    await expect(page.locator('#inn-pill')).toContainText('7');
+  });
+
+  test('#103: adding new catcher auto-selects them', async ({ page }) => {
+    await startGame(page, { mode: 'simple', homeCatcher: 'CatcherA' });
+    // Open catcher picker
+    const catcherChange = page.locator('#catcher-section .btn-sm', { hasText: 'Change' });
+    await catcherChange.click();
+    // Add new catcher
+    await page.fill('#new-c-name', 'New Catcher');
+    await page.fill('#new-c-num', '7');
+    await page.locator('#catcher-section').locator('text=Add').click();
+    // New catcher should be selected
+    const activeRow = page.locator('.player-row', { hasText: 'New Catcher' });
+    await expect(activeRow.locator('.badge-active')).toBeVisible();
+  });
+
+  test('#100: undo after non-pitch out side-retired reverts fully', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    // Get to 2 outs via non-pitch outs
+    await page.locator('#simple-content .adv-secondary-btn', { hasText: '+ Out' }).click();
+    await page.locator('#simple-content .adv-secondary-btn', { hasText: '+ Out' }).click();
+    // Add a pitch for state to track
+    await page.click('text=+ Pitch');
+    // Third out via non-pitch out
+    await page.locator('#simple-content .adv-secondary-btn', { hasText: '+ Out' }).click();
+    // Side retired modal
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+    await page.locator('.modal-btn.amber').click();
+    // Now in BOT 1
+    await expect(page.locator('#inn-pill')).toContainText('BOT');
+    // Undo should go back to TOP 1 with 2 outs
+    await page.locator('#undo-btn-simple').click();
+    await expect(page.locator('#inn-pill')).toContainText('TOP');
+  });
 });

--- a/tests/v2-features.spec.ts
+++ b/tests/v2-features.spec.ts
@@ -567,12 +567,12 @@ test.describe('Scoreboard improvements (#87-#92)', () => {
     await expect(page.locator('#pitcher-name-display .stats-link')).toHaveCount(0);
   });
 
-  test('9-inning game prompts end when not tied', async ({ page }) => {
+  test('max-innings game prompts end when not tied', async ({ page }) => {
     await startGame(page, { mode: 'simple' });
-    // Give away team a 1-run lead
+    // Default max innings is 6. Give away team a 1-run lead
     await page.click('.sb-adj >> nth=1');
-    // Play through 9 innings (18 half-innings)
-    for (let i = 0; i < 18; i++) {
+    // Play through 6 innings (12 half-innings)
+    for (let i = 0; i < 12; i++) {
       await page.click('.end-half-btn');
       await page.click('.modal-btn.amber');
     }
@@ -581,29 +581,29 @@ test.describe('Scoreboard improvements (#87-#92)', () => {
     await expect(page.locator('.modal-box')).toContainText('Game complete');
   });
 
-  test('9-inning tied game allows extra innings', async ({ page }) => {
+  test('max-innings tied game allows extra innings', async ({ page }) => {
     await startGame(page, { mode: 'simple' });
-    // Play through 9 innings (18 half-innings), score stays 0-0
-    for (let i = 0; i < 18; i++) {
+    // Play through 6 innings (12 half-innings), score stays 0-0
+    for (let i = 0; i < 12; i++) {
       await page.click('.end-half-btn');
       await page.click('.modal-btn.amber');
     }
     // Should NOT see game complete modal since tied 0-0
     await page.waitForTimeout(500);
     await expect(page.locator('.modal-overlay')).toHaveCount(0);
-    await expect(page.locator('#inn-pill')).toContainText('10');
+    await expect(page.locator('#inn-pill')).toContainText('7');
   });
 
-  test('9-inning modal Continue allows extra innings', async ({ page }) => {
+  test('max-innings modal Continue allows extra innings', async ({ page }) => {
     await startGame(page, { mode: 'simple' });
     await page.click('.sb-adj >> nth=1');
-    for (let i = 0; i < 18; i++) {
+    for (let i = 0; i < 12; i++) {
       await page.click('.end-half-btn');
       await page.click('.modal-btn.amber');
     }
     await page.waitForSelector('.modal-overlay', { timeout: 3000 });
     await page.locator('.modal-btn', { hasText: 'Continue' }).click();
-    await expect(page.locator('#inn-pill')).toContainText('10');
+    await expect(page.locator('#inn-pill')).toContainText('7');
   });
 
   test('editable inning cell updates score', async ({ page }) => {
@@ -665,5 +665,194 @@ test.describe('Scoreboard improvements (#87-#92)', () => {
     if (download) {
       expect(download.suggestedFilename()).toBe('game-stats.png');
     }
+  });
+});
+
+test.describe('Batch fixes (#94-#103)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearState(page);
+  });
+
+  test('#94: umpire names carry from setup to summary', async ({ page }) => {
+    await page.click('.new-game-btn');
+    await page.waitForSelector('#screen-setup.active');
+    await page.click('#mode-simple');
+    await page.fill('#s-home', 'Eagles');
+    await page.fill('#s-away', 'Hawks');
+    await page.fill('#hp-name', 'Jake');
+    await page.fill('#ap-name', 'Sam');
+    await page.fill('#s-ump-plate', 'John Smith');
+    await page.fill('#s-ump-base', 'Mike Jones');
+    await page.click('.start-btn');
+    await page.waitForSelector('#screen-game.active');
+    // End game without visiting summary first
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'End game' }).click();
+    await page.locator('.modal-btn.red', { hasText: 'End now' }).click();
+    await page.waitForSelector('#screen-history.active');
+    // View summary from history
+    await page.locator('.hist-action-btn', { hasText: 'Summary' }).first().click();
+    await page.waitForSelector('#screen-summary.active');
+    await expect(page.locator('#sum-pu-name')).toHaveValue('John Smith');
+    await expect(page.locator('#sum-bu-name')).toHaveValue('Mike Jones');
+  });
+
+  test('#95: division field pre-populated from config name', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'Game summary' }).click();
+    await page.waitForSelector('#screen-summary.active');
+    // Division should be pre-populated with config name
+    const divVal = await page.locator('#sum-division').inputValue();
+    expect(divVal).toBeTruthy();
+    expect(divVal).toContain('Default');
+  });
+
+  test('#95: division appears in export text', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'Game summary' }).click();
+    await page.waitForSelector('#screen-summary.active');
+    await page.fill('#sum-division', 'Minors 8');
+    await page.click('text=‹ Back');
+    // End the game
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'End game' }).click();
+    await page.locator('.modal-btn.red').click();
+    await page.waitForSelector('#screen-history.active');
+    // Open summary from history and generate export
+    await page.locator('.hist-action-btn', { hasText: 'Summary' }).first().click();
+    await page.waitForSelector('#screen-summary.active');
+    await expect(page.locator('#sum-division')).toHaveValue('Minors 8');
+  });
+
+  test('#96: older completed games are collapsed', async ({ page }) => {
+    // Start and end 3 games
+    for (let i = 0; i < 3; i++) {
+      await startGame(page, { mode: 'simple', homeTeam: `Team${i}H`, awayTeam: `Team${i}A` });
+      await page.click('.menu-btn');
+      await page.locator('.hbg-item', { hasText: 'End game' }).click();
+      await page.locator('.modal-btn.red').click();
+      await page.waitForSelector('#screen-history.active');
+    }
+    // First game (most recent) should be expanded
+    const firstDetail = page.locator('#hist-detail-0');
+    await expect(firstDetail).toBeVisible();
+    // Third game should be collapsed
+    const thirdDetail = page.locator('#hist-detail-2');
+    await expect(thirdDetail).toBeHidden();
+    // Should have a "Show details" button for collapsed card
+    const showBtn = page.locator('.swipe-card-wrap').nth(2).locator('text=Show details');
+    await expect(showBtn).toBeVisible();
+    // Clicking Show details expands it
+    await showBtn.click();
+    await expect(thirdDetail).toBeVisible();
+  });
+
+  test('#97: game mercy modal appears at run differential limit', async ({ page }) => {
+    // Set game mercy to 3 via config
+    await page.evaluate(() => {
+      (window as any).saveState();
+    }).catch(() => {});
+    await page.evaluate(() => {
+      const s = JSON.parse(localStorage.getItem('spc_v1') || '{}');
+      if (!s.configs) s.configs = [];
+      if (s.configs[0]) s.configs[0].mercyGame = 3;
+      localStorage.setItem('spc_v1', JSON.stringify(s));
+    });
+    await page.reload();
+    await page.waitForSelector('#screen-history.active');
+    await startGame(page, { mode: 'simple' });
+    // Add 3 runs to away team
+    for (let i = 0; i < 3; i++) {
+      await page.click('.sb-adj >> nth=1');
+    }
+    // Game mercy modal should appear
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+    await expect(page.locator('.modal-box')).toContainText('Game mercy reached');
+  });
+
+  test('#98: R column header is centered', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    // R header should be visible
+    const rHeader = page.locator('.inn-sb-hdr', { hasText: 'R' });
+    await expect(rHeader).toBeVisible();
+  });
+
+  test('#100: undo after BIP side-retired reverts fully', async ({ page }) => {
+    await startGame(page, { mode: 'advanced' });
+    // Advance to 2 outs
+    await page.click('.adv-secondary-btn >> text=+ Out');
+    await page.click('.adv-secondary-btn >> text=+ Out');
+    await expect(page.locator('#out1')).toHaveClass(/filled/);
+    // Throw a BIP pitch
+    const bipBtn = page.locator('.pitch-btn').filter({ hasText: /Play/ });
+    await bipBtn.click();
+    await page.waitForSelector('#bip-overlay[style*="flex"]', { timeout: 3000 });
+    // Mark as out (3rd out → side retired)
+    await page.click('.bip-btn.out');
+    await waitForFlashToClear(page);
+    // Side retired modal appears
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+    await expect(page.locator('.modal-box')).toContainText('End half inning');
+    // Click End to advance to next half
+    await page.locator('.modal-btn.amber').click();
+    // Now in Bottom of Inning 1
+    await expect(page.locator('#inn-pill')).toContainText('BOT');
+    // Undo — should revert to 2 outs in Top 1 before the BIP
+    await page.click('#undo-btn-adv');
+    await expect(page.locator('#inn-pill')).toContainText('TOP');
+    await expect(page.locator('#out1')).toHaveClass(/filled/);
+  });
+
+  test('#101: button mapping options are vertically centered', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    await page.click('.menu-btn');
+    await page.locator('#game-hbg-menu .hbg-item', { hasText: 'Button mapping' }).click();
+    await page.waitForSelector('#btn-map-overlay', { timeout: 3000 });
+    // Check that options have display:flex and align-items:center
+    const firstOpt = page.locator('#btn-map-rows div[onclick*="setBtnMapping"]').first();
+    await expect(firstOpt).toHaveCSS('display', 'flex');
+    await expect(firstOpt).toHaveCSS('align-items', 'center');
+  });
+
+  test('#102: 0-0 game shows scoreboard not score-pill', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    // Go back to history (close game)
+    await page.click('.menu-btn');
+    await page.locator('.hbg-item', { hasText: 'Close' }).click();
+    await page.waitForSelector('#screen-history.active');
+    // Should see a scoreboard, not a score-pill
+    await expect(page.locator('.hist-scoreboard')).toBeVisible();
+    await expect(page.locator('.score-pill')).toHaveCount(0);
+  });
+
+  test('#103: adding new pitcher auto-selects them', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    // Open pitcher picker
+    await page.click('#p-change-btn');
+    // Add new pitcher
+    await page.fill('#new-p-name', 'New Guy');
+    await page.fill('#new-p-num', '99');
+    await page.click('text=Add');
+    // New pitcher should be selected (active badge visible on last row)
+    const activeLabels = page.locator('.badge-active');
+    await expect(activeLabels).toHaveCount(1);
+    // The active badge should be on the row with "New Guy"
+    const activeRow = page.locator('.player-row', { hasText: 'New Guy' });
+    await expect(activeRow.locator('.badge-active')).toBeVisible();
+  });
+
+  test('#99: max innings default is 6', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    // Play 6 innings with a 1-run lead
+    await page.click('.sb-adj >> nth=1');
+    for (let i = 0; i < 12; i++) {
+      await page.click('.end-half-btn');
+      await page.click('.modal-btn.amber');
+    }
+    await page.waitForSelector('.modal-overlay', { timeout: 3000 });
+    await expect(page.locator('.modal-box')).toContainText('6 innings');
   });
 });


### PR DESCRIPTION
## Summary
- **#94**: Fix umpire names not carrying from setup to game summary — `endGame()` was calling `collectSummaryData()` which read empty summary form fields, overwriting values saved during setup
- **#95**: Add division field to game summary screen, pre-populated from active config name. Division is included in export text and as email subject prefix
- **#96**: Collapse older completed history cards — only live games and the most recent completed game are expanded by default; others show a "Show details" toggle
- **#97**: Add full-game mercy rule — new `mercyGame` config field triggers an end-game modal when run differential reaches the limit, with a 1-run warning alert
- **#98**: Center R column header in both game and history inning scoreboards via `justify-content: center`
- **#99**: Configurable max innings (default 6, empty = 9) — replaces hardcoded 9-inning auto-end logic; extra innings allowed when tied
- **#100**: Fix undo after BIP side-retired — `endHalfInning` was creating a duplicate snapshot; now skips the snapshot when called from `confirmSideRetired` since `throwPitch`/`recordNonPitchOut` already saved one
- **#101**: Vertically center button mapping option labels using `display:flex; align-items:center; justify-content:center`
- **#102**: Show inning scoreboard format for 0-0 games instead of falling back to legacy score-pill
- **#103**: Auto-select newly added pitcher as active (catcher already had this behavior)

## Test plan
- [x] 194 tests passing (183 existing + 11 new)
- [x] New tests cover: umpire name carryover, division field population and persistence, collapsed history cards with expand/collapse, game mercy modal, R column alignment, BIP undo reversion, button mapping alignment CSS, 0-0 scoreboard display, auto-select new pitcher, max innings default
- [x] Existing 9-inning tests updated to use default 6-inning config
- [x] Android assets/index.html synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)