### PR TITLE
Fix button mapping not reloading on game resume

### DIFF
--- a/android/app/src/main/assets/index.html
+++ b/android/app/src/main/assets/index.html
@@ -2178,6 +2178,7 @@ function resumeGame(gi){
   const g=state.games[gi];state.currentGame=g;state.games.splice(gi,1);
   const cfg=state.configs.find(c=>c.id===g.configId);
   if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
+  applyModeDefaults();
   saveState();renderGame();showScreen('game');
 }
 function confirmDelGame(i){

--- a/app/index.html
+++ b/app/index.html
@@ -2178,6 +2178,7 @@ function resumeGame(gi){
   const g=state.games[gi];state.currentGame=g;state.games.splice(gi,1);
   const cfg=state.configs.find(c=>c.id===g.configId);
   if(cfg){PITCH_MAX=cfg.pitchMax;C_INN_LIM=cfg.catcherInnMax;MERCY_RUNS=cfg.mercyRuns||0;PITCH_C_LIM=cfg.pitchCatchLim||0;MERCY_GAME=cfg.mercyGame||0;MAX_INN=cfg.maxInnings||9;}
+  applyModeDefaults();
   saveState();renderGame();showScreen('game');
 }
 function confirmDelGame(i){

--- a/tests/v2-features.spec.ts
+++ b/tests/v2-features.spec.ts
@@ -1139,6 +1139,21 @@ test.describe('Batch fixes (#105-#111)', () => {
     expect(hintsHtml).toContain('Strike');
   });
 
+  test('#107: resuming game loads correct mode mapping', async ({ page }) => {
+    await startGame(page, { mode: 'simple' });
+    // Change simple mapping via JS
+    await page.evaluate(() => { (window as any).setBtnMapping('volUp', 'undo'); });
+    // Close to history (keeps as live game)
+    await page.click('.menu-btn');
+    await page.locator('#game-hbg-menu .hbg-item').filter({ hasText: 'Close' }).click();
+    await page.waitForSelector('#screen-history.active');
+    // Resume the game — should reload simple mapping with our change
+    await page.locator('.hist-action-btn', { hasText: 'Resume' }).click();
+    await page.waitForSelector('#screen-game.active');
+    const hintsHtml = await page.locator('.btn-hints').innerHTML();
+    expect(hintsHtml).toContain('Undo');
+  });
+
   // #108: Button hint backwards K SVG
   test('#108: calledStrike hint uses backwards K SVG', async ({ page }) => {
     await startGame(page, { mode: 'advanced' });


### PR DESCRIPTION
## Summary
- `resumeGame()` was missing the `applyModeDefaults()` call, so resuming a game from history kept whatever in-memory `btnMapping` was left from the previous game instead of loading the saved per-mode mapping
- Changing mapping in a simple game then resuming an advanced game (or vice versa) would show the wrong mode's mapping

## Test plan
- [x] 225 Playwright E2E tests pass (1 new regression test)
- [ ] Start simple game, change button mapping, close to history
- [ ] Start advanced game, verify advanced defaults shown (not simple changes)
- [ ] Close advanced game, resume simple game, verify simple mapping preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)