### PR TITLE
Sync button mapping phone mockup with hero layout

### DIFF
--- a/website/android-beta.html
+++ b/website/android-beta.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Sign up to beta test Simple Pitch Counter on Android. Be the first to try it on Google Play.">
 <link rel="canonical" href="https://simplepitchcounter.com/android-beta/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Android Beta — Simple Pitch Counter">
 <meta property="og:description" content="Sign up to beta test Simple Pitch Counter on Android. Be the first to try it on Google Play.">

--- a/website/articles.html
+++ b/website/articles.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Guides and reference articles for youth baseball parents, coaches, and volunteers. Pitch count rules, rest days, catcher limits, and more.">
 <link rel="canonical" href="https://simplepitchcounter.com/articles/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Youth Baseball Guides for Parents and Coaches">
 <meta property="og:description" content="Guides and reference articles for youth baseball parents, coaches, and volunteers.">

--- a/website/catcher-innings-rules.html
+++ b/website/catcher-innings-rules.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Little League catcher-pitcher eligibility rules explained. Learn how many innings a kid can catch, when catchers can't pitch, and how catcher innings interact with pitch counts.">
 <link rel="canonical" href="https://simplepitchcounter.com/catcher-innings-rules/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Little League Catcher Rules - How Many Innings Can a Kid Catch?">
 <meta property="og:description" content="Little League catcher-pitcher eligibility rules explained. Learn how many innings a kid can catch, when catchers can't pitch, and how catcher innings interact with pitch counts.">

--- a/website/contact.html
+++ b/website/contact.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Get in touch with the developer of Simple Pitch Counter. Questions, suggestions, or partnership inquiries welcome.">
 <link rel="canonical" href="https://simplepitchcounter.com/contact/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Contact — Simple Pitch Counter">
 <meta property="og:description" content="Get in touch with the developer of Simple Pitch Counter.">

--- a/website/feedback.html
+++ b/website/feedback.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Share your feedback about Simple Pitch Counter. Report bugs, suggest features, or tell us how the app is working for your team.">
 <link rel="canonical" href="https://simplepitchcounter.com/feedback/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Feedback — Simple Pitch Counter">
 <meta property="og:description" content="Share your feedback about Simple Pitch Counter. Help us improve the app.">

--- a/website/generate-og-images.mjs
+++ b/website/generate-og-images.mjs
@@ -1,0 +1,75 @@
+import { chromium } from 'playwright';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const articles = [
+  {
+    file: 'og-pitch-count-rules.png',
+    tag: 'Rules Reference',
+    title: 'Little League Pitch Count Rules 2026',
+    subtitle: 'Daily limits, rest-day charts, and catcher-pitcher restrictions for every age group',
+  },
+  {
+    file: 'og-parents-guide.png',
+    tag: 'For Parents',
+    title: 'You Don\'t Need to Know Baseball to Count Pitches',
+    subtitle: 'A guide for the parent who just volunteered to help at the field',
+  },
+  {
+    file: 'og-catcher-innings-rules.png',
+    tag: 'Rules Reference',
+    title: 'Catcher Rules: How Many Innings Can a Kid Catch?',
+    subtitle: 'Catcher-pitcher eligibility, why both positions are tracked, and common mistakes',
+  },
+  {
+    file: 'og-mercy-rule.png',
+    tag: 'Rules Reference',
+    title: 'The Mercy Rule Explained',
+    subtitle: 'The 10-run rule, how shortened games affect pitch counts and rest days',
+  },
+  {
+    file: 'og-what-is-pitch-count.png',
+    tag: 'For Volunteers',
+    title: 'What Is a Pitch Counter?',
+    subtitle: 'The volunteer role that protects young arms at every Little League game',
+  },
+  {
+    file: 'og-travel-ball-pitch-counts.png',
+    tag: 'Travel Ball',
+    title: 'Travel Ball vs. Rec League Pitch Counts',
+    subtitle: 'Why travel ball parents need to track on their own',
+  },
+];
+
+const templatePath = join(__dirname, 'og-template.html');
+const imagesDir = join(__dirname, 'images');
+
+try { mkdirSync(imagesDir, { recursive: true }); } catch {}
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1200, height: 630 } });
+
+for (const article of articles) {
+  const page = await context.newPage();
+  await page.goto(`file://${templatePath.replace(/\\/g, '/')}`);
+  await page.waitForLoadState('networkidle');
+
+  await page.evaluate(({ tag, title, subtitle }) => {
+    document.getElementById('tag').textContent = tag;
+    document.getElementById('title').textContent = title;
+    document.getElementById('subtitle').textContent = subtitle;
+  }, article);
+
+  await page.waitForTimeout(500);
+
+  const outputPath = join(imagesDir, article.file);
+  await page.screenshot({ path: outputPath, type: 'png' });
+  console.log(`Generated: ${article.file}`);
+  await page.close();
+}
+
+await browser.close();
+console.log('All OG images generated.');

--- a/website/index.html
+++ b/website/index.html
@@ -1314,6 +1314,35 @@
                 <span>+ Out</span>
                 <span>Next batter ›</span>
               </div>
+              <div class="pc-alert warn">
+                <div class="pc-alert-dot"></div>
+                <span>Approaching 50 pitch limit, 13 remain.</span>
+              </div>
+              <!-- Catcher section (matches hero) -->
+              <div class="pc-catcher-section">
+                <div class="pc-catcher-header">
+                  <div>
+                    <div class="pc-section-lbl">Catcher</div>
+                    <div class="pc-catcher-name">Mike C. <span style="color:rgba(60,60,67,.35);font-weight:500">#8</span></div>
+                  </div>
+                  <div class="pc-change-btn">Change</div>
+                </div>
+                <div class="pc-catcher-card">
+                  <div>
+                    <div class="pc-catcher-remaining">2 innings remaining</div>
+                    <div class="pc-inn-pips">
+                      <div class="pc-inn-pip filled"></div>
+                      <div class="pc-inn-pip filled"></div>
+                      <div class="pc-inn-pip"></div>
+                      <div class="pc-inn-pip"></div>
+                    </div>
+                  </div>
+                  <div>
+                    <div class="pc-catcher-count">2</div>
+                    <div class="pc-catcher-of">of 4 inn.</div>
+                  </div>
+                </div>
+              </div>
               <!-- Button hints showing active mapping -->
               <div class="pc-btn-hints">
                 <div class="pc-btn-hint" style="background:rgba(255,59,48,0.08);border:1px solid rgba(255,59,48,0.2)">
@@ -1326,10 +1355,6 @@
                   <span class="pc-btn-hint-dot" style="background:#1A6BFF"></span>
                   <span style="font-size:10px;font-weight:700;color:#1A6BFF">Ball</span>
                 </div>
-              </div>
-              <div class="pc-alert warn">
-                <div class="pc-alert-dot"></div>
-                <span>Approaching 50 pitch limit, 13 remain.</span>
               </div>
             </div>
             </div><!-- end phone-inner -->

--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Simple Pitch Counter — the free app for tracking baseball and softball pitch counts, rest-day rules, and catcher innings during little league and youth games. iOS and Android.">
 <link rel="canonical" href="https://simplepitchcounter.com/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Simple Pitch Counter — Baseball & Softball Pitch Tracking">
 <meta property="og:description" content="Track pitch counts, rest-day rules, and game summaries for youth baseball and softball. Free, no ads, no accounts.">

--- a/website/mercy-rule.html
+++ b/website/mercy-rule.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Little League mercy rule and ten run rule explained for parents and coaches. How the run-ahead rule works, when games end early, and why pitch counts still matter in shortened games.">
 <link rel="canonical" href="https://simplepitchcounter.com/mercy-rule/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Little League Mercy Rule Explained - The 10-Run Rule and How It Works">
 <meta property="og:description" content="Little League mercy rule and ten run rule explained for parents and coaches. How the run-ahead rule works, when games end early, and why pitch counts still matter in shortened games.">

--- a/website/parents-guide.html
+++ b/website/parents-guide.html
@@ -6,7 +6,6 @@
 <meta name="description" content="New to baseball volunteering? Here's how to track pitch counts at Little League games without knowing all the rules. A parent's honest guide to keeping kids' arms safe.">
 <link rel="canonical" href="https://simplepitchcounter.com/parents-guide/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="The Parent's Guide to Pitch Counting - You Don't Need to Know Baseball">
 <meta property="og:description" content="New to baseball volunteering? Here's how to track pitch counts at Little League games without knowing all the rules.">

--- a/website/pitch-count-rules.html
+++ b/website/pitch-count-rules.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Complete 2026 Little League pitch count rules, rest day charts by age, catcher-pitcher limits, and the finish-the-batter rule. Official reference for coaches and parents.">
 <link rel="canonical" href="https://simplepitchcounter.com/pitch-count-rules/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Little League Pitch Count Rules 2026 - Complete Guide">
 <meta property="og:description" content="Complete 2026 Little League pitch count rules, rest day charts by age, catcher-pitcher limits, and the finish-the-batter rule.">

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Simple Pitch Counter does not collect, store, or transmit any personal data. Everything stays on your device.">
 <link rel="canonical" href="https://simplepitchcounter.com/privacy/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Privacy Policy — Simple Pitch Counter">
 <meta property="og:description" content="Simple Pitch Counter does not collect, store, or transmit any personal data. Everything stays on your device.">

--- a/website/travel-ball-pitch-counts.html
+++ b/website/travel-ball-pitch-counts.html
@@ -6,7 +6,6 @@
 <meta name="description" content="Travel ball pitch count rules vary by organization, and some have none at all. Here's what parents need to know about protecting young arms in travel baseball vs. rec league.">
 <link rel="canonical" href="https://simplepitchcounter.com/travel-ball-pitch-counts/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="Travel Ball vs. Rec League Pitch Counts - What Parents Need to Know">
 <meta property="og:description" content="Travel ball pitch count rules vary by organization, and some have none at all. Here's what parents need to know about protecting young arms in travel baseball vs. rec league.">

--- a/website/what-is-pitch-count.html
+++ b/website/what-is-pitch-count.html
@@ -6,7 +6,6 @@
 <meta name="description" content="A pitch counter is the volunteer at a youth baseball game who tracks every pitch thrown. Here's what they do, who assigns them, and why the job matters for protecting young arms.">
 <link rel="canonical" href="https://simplepitchcounter.com/what-is-pitch-count/">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <meta property="og:title" content="What Is a Pitch Counter? The Volunteer Role That Protects Young Arms">
 <meta property="og:description" content="A pitch counter is the volunteer at a youth baseball game who tracks every pitch thrown. Here's what they do, who assigns them, and why the job matters.">


### PR DESCRIPTION
## Summary
- Moved pitch limit alert above the volume button hints to match the hero mockup order
- Added catcher section (Mike C. #8, 2 of 4 innings) matching the hero phone mockup
- Button mapping mockup now follows the same layout: secondary actions → alert → catcher → button hints

## Test plan
- [ ] Verify button mapping section phone mockup matches hero phone mockup layout
- [ ] Confirm favicon loads on all pages (clear cache if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)