### PR TITLE
V2.43 — HBP counts as walk + pitcher list export shows HBP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All changes to `index.html` are documented here. Add this file to the project so
 
 ---
 
+## [2026-05-03] V2.43 — HBP counts as walk; HBP added to pitcher list export
+
+**Files:** `app/index.html`, `android/app/src/main/assets/index.html`, `build.gradle.kts`, `project.pbxproj`, `tests/v2-features.spec.ts`
+**Issues:** #141, #142
+
+### Bug fixes
+- **HBP now increments BB hero count** (#141) — recording a hit-by-pitch now bumps both the pitcher's `bbs` (walks) and `hbps` counters so the BB (Walks) hero in the stats overlay reflects the runner reaching base. HBP remains tracked separately as its own stat line.
+
+### Improvements
+- **Pitcher-list export image now shows K · BB · HBP per pitcher** (#142) — the shared multi-pitcher card rendered via `renderPitcherListCardToCanvas` now surfaces the K/BB/HBP line below team/IP/last-batter info. Individual stats card already included HBP from V2.42.
+
+### Testing & versioning
+- Updated existing HBP-vs-walks test to assert BB increments (was: BB stays 0)
+- Added 3 tests: BB hero shows 1 after HBP, pitcher-list canvas renders, and stats card statLineHtml includes HBP
+- Version bumped to 2.43 across iOS, Android, and the in-app About page
+
+---
+
 ## [2026-05-03] V2.42 — Hit By Pitch and game clock UX fixes
 
 **Files:** `app/index.html`, `android/app/src/main/assets/index.html`, `build.gradle.kts`, `project.pbxproj`, `tests/v2-features.spec.ts`

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = gitCommitCount.get()
-        versionName = "2.42"
+        versionName = "2.43"
     }
 
     signingConfigs {

--- a/android/app/src/main/assets/index.html
+++ b/android/app/src/main/assets/index.html
@@ -841,7 +841,7 @@ textarea{resize:vertical;min-height:56px}
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.42</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.43</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">
@@ -1192,6 +1192,7 @@ function recordHBP(){
   ap.pitchTypes=ap.pitchTypes||{B:0,CS:0,SS:0,F:0,BIP:0};
   ap.pitchTypes.B=(ap.pitchTypes.B||0)+1;
   ap.hbps=(ap.hbps||0)+1;
+  ap.bbs=(ap.bbs||0)+1;
   if(!g.atBatLog)g.atBatLog=[];
   g.atBatLog.push('B');
   haptic('medium');animatePop();
@@ -1800,16 +1801,19 @@ function renderPitcherListCardToCanvas(gameData){
     allP.forEach(p=>{
       const s=pitcherDerivedStats(p);const ri2=restInfo(p.pitches);
       const rc=!ri2||ri2.days===0?'#34C759':ri2.days===1?'#FF9500':'#FF3B30';
-      ctx.fillStyle='rgba(255,255,255,.06)';ctx.beginPath();ctx.roundRect(pad,y,W-pad*2,80,14);ctx.fill();
+      const rowH=104;
+      ctx.fillStyle='rgba(255,255,255,.06)';ctx.beginPath();ctx.roundRect(pad,y,W-pad*2,rowH,14);ctx.fill();
       ctx.fillStyle='#fff';ctx.font='bold 22px -apple-system,system-ui,sans-serif';
       ctx.fillText(p.name+(p.num?' #'+p.num:''),pad+16,y+28);
-      ctx.fillStyle='rgba(235,235,245,.5)';ctx.font='500 16px -apple-system,system-ui,sans-serif';
+      ctx.fillStyle='rgba(235,235,245,.5)';ctx.font='500 15px -apple-system,system-ui,sans-serif';
       ctx.fillText(`${p.team} · ${s.ip} IP · Last batter: ${p.lastBatterPitches||0}`,pad+16,y+52);
+      ctx.fillStyle='rgba(235,235,245,.6)';ctx.font='600 14px -apple-system,system-ui,sans-serif';
+      ctx.fillText(`K: ${s.ks} · BB: ${s.bbs} · HBP: ${s.hbps}`,pad+16,y+76);
       ctx.fillStyle='#fff';ctx.font='bold 30px -apple-system,system-ui,sans-serif';
       const ct=String(p.pitches);const cw=ctx.measureText(ct).width;ctx.fillText(ct,W-pad-16-cw,y+34);
       ctx.fillStyle=rc;ctx.font='600 14px -apple-system,system-ui,sans-serif';
       const rt=ri2?ri2.label:'';const rw=ctx.measureText(rt).width;ctx.fillText(rt,W-pad-16-rw,y+56);
-      y+=92;
+      y+=rowH+12;
     });
     y+=10;ctx.fillStyle='rgba(235,235,245,.3)';ctx.font='500 16px -apple-system,system-ui,sans-serif';
     const tag='Simple Pitch Counter';const tagW=ctx.measureText(tag).width;ctx.fillText(tag,(W-tagW)/2,y+=20);

--- a/app/Little League Pitch Counter.xcodeproj/project.pbxproj
+++ b/app/Little League Pitch Counter.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.42;
+				MARKETING_VERSION = 2.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -356,7 +356,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.42;
+				MARKETING_VERSION = 2.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/app/index.html
+++ b/app/index.html
@@ -841,7 +841,7 @@ textarea{resize:vertical;min-height:56px}
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.42</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.43</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">
@@ -1192,6 +1192,7 @@ function recordHBP(){
   ap.pitchTypes=ap.pitchTypes||{B:0,CS:0,SS:0,F:0,BIP:0};
   ap.pitchTypes.B=(ap.pitchTypes.B||0)+1;
   ap.hbps=(ap.hbps||0)+1;
+  ap.bbs=(ap.bbs||0)+1;
   if(!g.atBatLog)g.atBatLog=[];
   g.atBatLog.push('B');
   haptic('medium');animatePop();
@@ -1800,16 +1801,19 @@ function renderPitcherListCardToCanvas(gameData){
     allP.forEach(p=>{
       const s=pitcherDerivedStats(p);const ri2=restInfo(p.pitches);
       const rc=!ri2||ri2.days===0?'#34C759':ri2.days===1?'#FF9500':'#FF3B30';
-      ctx.fillStyle='rgba(255,255,255,.06)';ctx.beginPath();ctx.roundRect(pad,y,W-pad*2,80,14);ctx.fill();
+      const rowH=104;
+      ctx.fillStyle='rgba(255,255,255,.06)';ctx.beginPath();ctx.roundRect(pad,y,W-pad*2,rowH,14);ctx.fill();
       ctx.fillStyle='#fff';ctx.font='bold 22px -apple-system,system-ui,sans-serif';
       ctx.fillText(p.name+(p.num?' #'+p.num:''),pad+16,y+28);
-      ctx.fillStyle='rgba(235,235,245,.5)';ctx.font='500 16px -apple-system,system-ui,sans-serif';
+      ctx.fillStyle='rgba(235,235,245,.5)';ctx.font='500 15px -apple-system,system-ui,sans-serif';
       ctx.fillText(`${p.team} · ${s.ip} IP · Last batter: ${p.lastBatterPitches||0}`,pad+16,y+52);
+      ctx.fillStyle='rgba(235,235,245,.6)';ctx.font='600 14px -apple-system,system-ui,sans-serif';
+      ctx.fillText(`K: ${s.ks} · BB: ${s.bbs} · HBP: ${s.hbps}`,pad+16,y+76);
       ctx.fillStyle='#fff';ctx.font='bold 30px -apple-system,system-ui,sans-serif';
       const ct=String(p.pitches);const cw=ctx.measureText(ct).width;ctx.fillText(ct,W-pad-16-cw,y+34);
       ctx.fillStyle=rc;ctx.font='600 14px -apple-system,system-ui,sans-serif';
       const rt=ri2?ri2.label:'';const rw=ctx.measureText(rt).width;ctx.fillText(rt,W-pad-16-rw,y+56);
-      y+=92;
+      y+=rowH+12;
     });
     y+=10;ctx.fillStyle='rgba(235,235,245,.3)';ctx.font='500 16px -apple-system,system-ui,sans-serif';
     const tag='Simple Pitch Counter';const tagW=ctx.measureText(tag).width;ctx.fillText(tag,(W-tagW)/2,y+=20);

--- a/tests/v2-features.spec.ts
+++ b/tests/v2-features.spec.ts
@@ -1377,7 +1377,7 @@ test.describe('#136: Hit By Pitch button', () => {
     expect(outs).toBe(0);
   });
 
-  test('HBP does not increment walks', async ({ page }) => {
+  test('HBP increments walks counter (treated as a free pass)', async ({ page }) => {
     await startGame(page, { mode: 'advanced' });
     await page.locator('#adv-content .adv-secondary-btn', { hasText: '+ HBP' }).click();
     await waitForFlashToClear(page);
@@ -1385,7 +1385,7 @@ test.describe('#136: Hit By Pitch button', () => {
       const s = JSON.parse(localStorage.getItem('spc_v1') || '{}');
       return s.currentGame.home.pitchers[0].bbs || 0;
     });
-    expect(bbs).toBe(0);
+    expect(bbs).toBe(1);
   });
 
   test('HBP can be undone', async ({ page }) => {
@@ -1396,20 +1396,54 @@ test.describe('#136: Hit By Pitch button', () => {
     const data = await page.evaluate(() => {
       const s = JSON.parse(localStorage.getItem('spc_v1') || '{}');
       const p = s.currentGame.home.pitchers[0];
-      return { pitches: p.pitches, hbps: p.hbps || 0 };
+      return { pitches: p.pitches, hbps: p.hbps || 0, bbs: p.bbs || 0 };
     });
     expect(data.pitches).toBe(0);
     expect(data.hbps).toBe(0);
+    expect(data.bbs).toBe(0);
   });
 
-  test('HBP appears in pitcher stats list when advanced mode', async ({ page }) => {
+  test('HBP increments BB hero in pitcher detail overlay', async ({ page }) => {
     await startGame(page, { mode: 'advanced' });
     await page.locator('#adv-content .adv-secondary-btn', { hasText: '+ HBP' }).click();
     await waitForFlashToClear(page);
-    await page.click('.menu-btn');
-    await page.waitForSelector('#game-hbg-menu.open');
-    await page.locator('#game-hbg-menu .hbg-item').filter({ hasText: 'Pitcher stats' }).click();
-    await expect(page.locator('body')).toContainText(/HBP/);
+    // Drill into the active pitcher's detail view
+    await page.evaluate(() => (window as any).showPitcherStatsDetail('home', 0));
+    const bbHero = page.locator('.stats-summary-box', { hasText: 'BB (Walks)' }).locator('.stats-summary-num');
+    await expect(bbHero).toHaveText('1');
+  });
+});
+
+test.describe('#142: Pitcher list export includes HBP', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearState(page);
+  });
+
+  test('pitcher list canvas renders K/BB/HBP per pitcher', async ({ page }) => {
+    await startGame(page, { mode: 'advanced' });
+    // Record one HBP so HBP > 0
+    await page.locator('#adv-content .adv-secondary-btn', { hasText: '+ HBP' }).click();
+    await waitForFlashToClear(page);
+    // Render the canvas and verify it returns a data URL (i.e. the function ran without error)
+    const dataUrl = await page.evaluate(() => {
+      return (window as any).renderPitcherListCardToCanvas();
+    });
+    expect(typeof dataUrl).toBe('string');
+    expect(dataUrl).toMatch(/^data:image\/png/);
+  });
+
+  test('pitcher stats canvas includes HBP row in stats list', async ({ page }) => {
+    await startGame(page, { mode: 'advanced' });
+    await page.locator('#adv-content .adv-secondary-btn', { hasText: '+ HBP' }).click();
+    await waitForFlashToClear(page);
+    // The stats card uses statLineHtml which includes "HBP (Hit By Pitch)"
+    const html = await page.evaluate(() => {
+      const s = JSON.parse(localStorage.getItem('spc_v1') || '{}');
+      const p = s.currentGame.home.pitchers[0];
+      return (window as any).statLineHtml(p);
+    });
+    expect(html).toContain('HBP (Hit By Pitch)');
   });
 });
 


### PR DESCRIPTION
## Summary
- HBP now increments the BB (walks) hero count in addition to its own HBP stat (#141) — fixes the iOS-tested behavior where the BB hero stayed at 0 after pressing HBP
- Pitcher-list export image now shows K · BB · HBP per pitcher (#142); individual pitcher stats card already included HBP from V2.42

Closes #141, #142.

## Test plan
- [x] 254 Playwright tests pass
- [ ] iOS simulator: tap HBP → BB hero shows 1, HBP stat shows 1
- [ ] iOS simulator: share pitcher list → image shows K/BB/HBP line per pitcher
- [ ] Android device: same two flows

## Versioning
2.42 → 2.43. Updated iOS `MARKETING_VERSION`, Android `versionName`, and the in-app About page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)