### PR TITLE
V2.48 — Force hero line break on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All changes to `index.html` are documented here. Add this file to the project so
 
 ---
 
+## [2026-05-03] V2.48 — Homepage hero line break
+
+**Files:** `website/index.html`
+
+### Polish
+- **Forced line break in hero headline** — `Track every pitch. Every game.` was wrapping inconsistently depending on viewport width; replaced the space between sentences with `<br>` so "Every game." always sits below "Track every pitch.", regardless of device size
+
+### Versioning
+- Version bumped to 2.48 across iOS, Android, and the in-app About page
+
+---
+
 ## [2026-05-03] V2.47 — OG image refresh: real screenshots, balanced layout
 
 **Files:** `marketing/og-image.html`, `marketing/finals/og-image-1200x630.png`, `website/images/og-image-1200x630.png`

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = gitCommitCount.get()
-        versionName = "2.47"
+        versionName = "2.48"
     }
 
     signingConfigs {

--- a/android/app/src/main/assets/index.html
+++ b/android/app/src/main/assets/index.html
@@ -841,7 +841,7 @@ textarea{resize:vertical;min-height:56px}
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.47</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.48</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">

--- a/app/Little League Pitch Counter.xcodeproj/project.pbxproj
+++ b/app/Little League Pitch Counter.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.47;
+				MARKETING_VERSION = 2.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -356,7 +356,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.47;
+				MARKETING_VERSION = 2.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/app/index.html
+++ b/app/index.html
@@ -841,7 +841,7 @@ textarea{resize:vertical;min-height:56px}
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.47</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.48</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">

--- a/website/index.html
+++ b/website/index.html
@@ -931,7 +931,7 @@
 <section class="hero">
   <div class="hero-text">
     <div class="hero-eyebrow">iOS & Android · Free · No Ads</div>
-    <h1>Track every pitch. <em>Every game.</em></h1>
+    <h1>Track every pitch.<br><em>Every game.</em></h1>
     <p class="hero-sub">Track pitch counts and every pitch type in real time. Simple mode for quick counting, Advanced mode for full ball-strike-out tracking — built for the dugout, not a desk.</p>
     <div class="cta-group">
       <a href="#download" class="btn-primary-cta">


### PR DESCRIPTION
## Summary
- Homepage hero \`Track every pitch. Every game.\` was wrapping inconsistently across viewport widths. Replaced the space with \`<br>\` so the second sentence always sits on its own line.
- Version bumped to 2.48

## Test plan
- [x] Version sync test passes
- [ ] Deploy index.html and visually confirm at desktop, tablet, and mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)