### PR TITLE
V2.50 — Hero font scales down on iPhone widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All changes to `index.html` are documented here. Add this file to the project so
 
 ---
 
+## [2026-05-03] V2.50 — Hero font scales down on iPhone widths
+
+**Files:** `website/index.html`
+
+### Polish
+- **Hero `h1` no longer wraps mid-sentence on iPhones** — the `clamp(2.6rem, 5vw, 4rem)` floor was 41.6px, which forced "Track every pitch." to wrap onto two lines on every iPhone width (375–430px). Lowered the floor to `2rem` (32px) so "Track every pitch." stays on one line and the `<br>` cleanly breaks to "Every game." underneath. Verified at 375px / 390px / 430px in headless Chromium.
+
+### Versioning
+- Version bumped to 2.50 across iOS, Android, and the in-app About page
+
+---
+
 ## [2026-05-03] V2.49 — README refresh
 
 **Files:** `README.md`

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = gitCommitCount.get()
-        versionName = "2.49"
+        versionName = "2.50"
     }
 
     signingConfigs {

--- a/android/app/src/main/assets/index.html
+++ b/android/app/src/main/assets/index.html
@@ -841,7 +841,7 @@ textarea{resize:vertical;min-height:56px}
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.49</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.50</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">

--- a/app/Little League Pitch Counter.xcodeproj/project.pbxproj
+++ b/app/Little League Pitch Counter.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.49;
+				MARKETING_VERSION = 2.50;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -356,7 +356,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.49;
+				MARKETING_VERSION = 2.50;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/app/index.html
+++ b/app/index.html
@@ -841,7 +841,7 @@ textarea{resize:vertical;min-height:56px}
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.49</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.50</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">

--- a/website/index.html
+++ b/website/index.html
@@ -192,7 +192,7 @@
   }
   h1 {
     font-family: 'DM Serif Display', serif;
-    font-size: clamp(2.6rem, 5vw, 4rem);
+    font-size: clamp(2rem, 5vw, 4rem);
     line-height: 1.08;
     color: var(--cream);
     margin-bottom: 24px;


### PR DESCRIPTION
## Summary
The hero h1 floor (\`clamp(2.6rem, 5vw, 4rem)\`) was 41.6px, which forced \`Track every pitch.\` to wrap mid-sentence on every iPhone width. Lowered to \`2rem\` (32px) so the first line stays whole and \`<br>\` cleanly drops \`Every game.\` below.

Verified at 375px / 390px / 430px in headless Chromium.

Version bumped to 2.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)