### PR TITLE
V2.56 — Hotfix: calc() whitespace in safe-area paddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All changes to `index.html` are documented here. Add this file to the project so
 
 ---
 
+## [2026-05-08] V2.56 — Hotfix: calc() whitespace in safe-area paddings
+
+**Files:** `app/index.html`, `app/Little League Pitch Counter.xcodeproj/project.pbxproj`, `android/app/build.gradle.kts`
+
+### Bug fix
+- **#156 follow-up — Safe-area padding rules silently no-op'd in WebKit.** Several `calc(var(--bottom-inset)+Npx)` and `calc(var(--top-inset)+var(--header-pad))` expressions were missing whitespace around the `+` operator. WebKit follows the CSS spec strictly here — without spaces, the parser rejects the expression and the property falls back, so the Game Summary's `padding-bottom` was effectively `0` regardless of the value. V2.55 bumped the value from 60px → 120px but neither was applied. Whitespace added across all 7 affected rules (history list, setup nav/content, summary nav/content, config nav, modal overlay, export/config/about screens). The fix lands the long-intended bottom padding so Save/Share aren't clipped at the bottom of the Game Summary on iPhone 17.
+
+### Versioning
+- Version bumped to 2.56 across iOS, Android, and the in-app About page (hotfix `.01` increment — pure CSS parsing fix, no behavior change)
+
+---
+
 ## [2026-05-08] V2.55 — Production bug fixes batch (#154–#158)
 
 **Files:** `app/index.html`, `app/ViewController.swift`, `app/Little League Pitch Counter.xcodeproj/project.pbxproj`, `android/app/build.gradle.kts`, `tests/v2-features.spec.ts`, `tests/about-screen.spec.ts`

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = gitCommitCount.get()
-        versionName = "2.55"
+        versionName = "2.56"
     }
 
     signingConfigs {

--- a/app/Little League Pitch Counter.xcodeproj/project.pbxproj
+++ b/app/Little League Pitch Counter.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.55;
+				MARKETING_VERSION = 2.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -356,7 +356,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.55;
+				MARKETING_VERSION = 2.56;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/app/index.html
+++ b/app/index.html
@@ -339,7 +339,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
   font-size:15px;font-weight:700;cursor:pointer;
 }
 .history-sep{height:1px;background:var(--sep)}
-.history-list{padding:12px 20px calc(var(--bottom-inset)+80px);display:flex;flex-direction:column;gap:10px}
+.history-list{padding:12px 20px calc(var(--bottom-inset) + 80px);display:flex;flex-direction:column;gap:10px}
 .hist-card{background:var(--card);border-radius:18px;box-shadow:0 1px 0 rgba(0,0,0,.05),0 2px 8px rgba(0,0,0,.06);overflow:hidden}
 .hist-card-body{padding:14px 16px 10px}
 .hist-card-top{margin-bottom:8px}
@@ -380,12 +380,12 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 /* ── Setup screen ── */
 .setup-nav{
   display:flex;align-items:center;justify-content:space-between;
-  padding:calc(var(--top-inset)+var(--header-pad)) 20px 16px;
+  padding:calc(var(--top-inset) + var(--header-pad)) 20px 16px;
   background:var(--bg);
 }
 .setup-nav-title{font-size:17px;font-weight:700}
 .setup-content{padding:0 20px;display:flex;flex-direction:column;gap:20px;
-  padding-bottom:calc(var(--bottom-inset)+100px)}
+  padding-bottom:calc(var(--bottom-inset) + 100px)}
 .section-header-lbl{font-size:13px;font-weight:600;color:var(--t2);text-transform:uppercase;letter-spacing:.6px;margin-bottom:8px;padding:0 4px}
 /* Mode cards */
 .mode-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px}
@@ -422,11 +422,11 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 /* ── Summary & Export ── */
 .summary-nav{
   display:flex;align-items:center;justify-content:space-between;
-  padding:calc(var(--top-inset)+var(--header-pad)) 20px 16px;
+  padding:calc(var(--top-inset) + var(--header-pad)) 20px 16px;
 }
 .summary-nav-title{font-size:17px;font-weight:700}
 .summary-content{padding:0 20px;display:flex;flex-direction:column;gap:16px;
-  padding-bottom:calc(var(--bottom-inset)+120px)}
+  padding-bottom:calc(var(--bottom-inset) + 120px)}
 .final-score-card{background:var(--dark);border-radius:18px;padding:18px 20px}
 .final-tag{font-size:11px;font-weight:700;color:var(--dark-label);text-transform:uppercase;letter-spacing:.8px;margin-bottom:12px}
 .final-teams{display:grid;grid-template-columns:1fr auto 1fr;align-items:center}
@@ -450,7 +450,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
   margin-bottom:10px;
 }
 /* Config screen */
-.config-nav{padding-top:calc(var(--top-inset)+var(--header-pad));padding-left:20px;padding-right:20px;padding-bottom:8px;background:var(--bg)}
+.config-nav{padding-top:calc(var(--top-inset) + var(--header-pad));padding-left:20px;padding-right:20px;padding-bottom:8px;background:var(--bg)}
 .config-item{display:flex;align-items:flex-start;justify-content:space-between;padding:12px 0;border-bottom:0.5px solid var(--sep)}
 .config-item:last-child{border-bottom:none}
 .config-name{font-size:14px;font-weight:600}
@@ -462,7 +462,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 .trash-btn:active{background:var(--bg)}
 
 /* ── Modal overlay ── */
-.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:500;padding:calc(var(--top-inset)+var(--header-pad)) 1.2rem calc(var(--bottom-inset)+1.2rem);overflow-y:auto}
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:500;padding:calc(var(--top-inset) + var(--header-pad)) 1.2rem calc(var(--bottom-inset) + 1.2rem);overflow-y:auto}
 .modal-box{background:var(--card);border-radius:var(--r-lg);padding:1.3rem;width:100%;max-width:360px;position:relative;flex-shrink:0}
 .modal-title{font-size:16px;font-weight:600;margin-bottom:.5rem}
 .modal-sub{font-size:14px;color:var(--t2);margin-bottom:1.1rem;line-height:1.5}
@@ -802,7 +802,7 @@ textarea{resize:vertical;min-height:56px}
     <div class="summary-nav-title">Export Summary</div>
     <div style="width:70px"></div>
   </div>
-  <div style="padding:0 20px;padding-bottom:calc(var(--bottom-inset)+40px)">
+  <div style="padding:0 20px;padding-bottom:calc(var(--bottom-inset) + 40px)">
     <div class="export-box" id="export-box"></div>
     <div style="display:flex;gap:8px">
       <div class="summary-action-btn" style="background:var(--blue)" onclick="copyExport(this)">Copy to clipboard</div>
@@ -818,7 +818,7 @@ textarea{resize:vertical;min-height:56px}
     <div style="font-size:17px;font-weight:700;margin:8px 0 4px">Configuration</div>
     <div style="font-size:13px;color:var(--t2);margin-bottom:12px">Pitch and catcher threshold presets and field list.</div>
   </div>
-  <div style="padding:0 20px;padding-bottom:calc(var(--bottom-inset)+40px)">
+  <div style="padding:0 20px;padding-bottom:calc(var(--bottom-inset) + 40px)">
     <div class="lbl" style="margin-bottom:6px">Presets</div>
     <div style="background:var(--card);border:1.5px solid var(--sep2);border-radius:var(--r-lg);padding:.95rem 1.05rem;margin-bottom:8px"><div id="config-list"></div></div>
     <div class="big-btn blue h54" style="margin-bottom:20px;font-size:16px" onclick="showConfigForm(null)">+ New configuration</div>
@@ -838,13 +838,13 @@ textarea{resize:vertical;min-height:56px}
     <div class="btn-sm" onclick="showScreen('history')">‹ Back</div>
     <div style="font-size:17px;font-weight:700;margin:8px 0 4px">About This App</div>
   </div>
-  <div style="padding:0 20px;padding-bottom:calc(var(--bottom-inset)+40px)">
+  <div style="padding:0 20px;padding-bottom:calc(var(--bottom-inset) + 40px)">
     <div style="background:var(--card);border:1.5px solid var(--sep2);border-radius:var(--r-lg);padding:1.2rem 1.1rem;margin-bottom:12px">
       <div style="display:flex;align-items:center;gap:14px;margin-bottom:16px">
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.55</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.56</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">


### PR DESCRIPTION
## Summary
V2.55's bump from 60px → 120px on `.summary-content`'s `padding-bottom` made no visible difference because the rule has been silently no-op'ing the whole time.

WebKit follows the CSS calc() spec strictly: the `+` and `-` operators **require whitespace on both sides**. Expressions like `calc(var(--bottom-inset)+120px)` are rejected and the property falls back to its initial value (`0` for padding). Chrome is more lenient, which is why this didn't show up in Playwright's chromium-only CI.

This PR adds whitespace around `+` in all 7 affected rules:
- `.history-list` padding shorthand
- `.setup-nav` / `.summary-nav` top-inset padding
- `.setup-content` / `.summary-content` bottom padding
- `.config-nav` top padding
- `.modal-overlay` shorthand padding
- The three inline `<div style="padding-bottom:calc(…)">` blocks for the Export, Config, and About screens

Net effect: the long-intended bottom padding actually applies now, so Save/Share aren't clipped on the iPhone 17 Game Summary screen — and a few other screens (Setup, History, modal overlay) get their proper safe-area padding back too.

## Test plan
- [x] All 264 Playwright E2E tests pass locally
- [x] Version 2.56 synced across iOS `MARKETING_VERSION`, Android `versionName`, and the in-app About page
- [ ] Visual check on iPhone 17 simulator: Game Summary scrolled to bottom — Save/Share buttons fully visible above the home indicator
- [ ] Visual check: Setup screen, History screen, and modal overlays still look correct (these had the same parsing bug, so they should now have their proper padding for the first time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)