### PR TITLE
V2.57 — Tune Game Summary bottom padding (24px over inset)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All changes to `index.html` are documented here. Add this file to the project so
 
 ---
 
+## [2026-05-08] V2.57 — Hotfix: tune Game Summary bottom padding
+
+**Files:** `app/index.html`, `app/Little League Pitch Counter.xcodeproj/project.pbxproj`, `android/app/build.gradle.kts`
+
+### Bug fix
+- `.summary-content` `padding-bottom` reduced from `calc(var(--bottom-inset) + 120px)` to `calc(var(--bottom-inset) + 24px)`. V2.55's `120px` was guessed from the broken (silently-zero) baseline, so once V2.56 made the rule actually apply, the cushion below Save/Share was way too generous. `24px` over the safe-area inset gives a small, intentional breathing room above the home indicator.
+
+### Versioning
+- Version bumped to 2.57 across iOS, Android, and the in-app About page (hotfix `.01` increment — single CSS value tune)
+
+---
+
 ## [2026-05-08] V2.56 — Hotfix: calc() whitespace in safe-area paddings
 
 **Files:** `app/index.html`, `app/Little League Pitch Counter.xcodeproj/project.pbxproj`, `android/app/build.gradle.kts`

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = gitCommitCount.get()
-        versionName = "2.56"
+        versionName = "2.57"
     }
 
     signingConfigs {

--- a/app/Little League Pitch Counter.xcodeproj/project.pbxproj
+++ b/app/Little League Pitch Counter.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.56;
+				MARKETING_VERSION = 2.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -356,7 +356,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.56;
+				MARKETING_VERSION = 2.57;
 				PRODUCT_BUNDLE_IDENTIFIER = "Thames-Productions.Little-League-Pitch-Counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/app/index.html
+++ b/app/index.html
@@ -426,7 +426,7 @@ button{touch-action:manipulation;-webkit-user-select:none;user-select:none;curso
 }
 .summary-nav-title{font-size:17px;font-weight:700}
 .summary-content{padding:0 20px;display:flex;flex-direction:column;gap:16px;
-  padding-bottom:calc(var(--bottom-inset) + 120px)}
+  padding-bottom:calc(var(--bottom-inset) + 24px)}
 .final-score-card{background:var(--dark);border-radius:18px;padding:18px 20px}
 .final-tag{font-size:11px;font-weight:700;color:var(--dark-label);text-transform:uppercase;letter-spacing:.8px;margin-bottom:12px}
 .final-teams{display:grid;grid-template-columns:1fr auto 1fr;align-items:center}
@@ -844,7 +844,7 @@ textarea{resize:vertical;min-height:56px}
         <div style="width:56px;height:56px;border-radius:14px;background:var(--blue);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff">#</div>
         <div>
           <div style="font-size:18px;font-weight:700">Simple Pitch Counter</div>
-          <div style="font-size:13px;color:var(--t2)">Version 2.56</div>
+          <div style="font-size:13px;color:var(--t2)">Version 2.57</div>
         </div>
       </div>
       <div style="font-size:14px;color:var(--t2);line-height:1.5">

--- a/tests/v2-features.spec.ts
+++ b/tests/v2-features.spec.ts
@@ -1752,7 +1752,7 @@ test.describe('Batch fixes (#154-#158)', () => {
   });
 
   // #156: Game summary bottom padding
-  test('#156: summary content has enough bottom padding for save/share buttons', async ({ page }) => {
+  test('#156: summary content has bottom padding combining safe-area inset and a positive offset', async ({ page }) => {
     await startGame(page, { mode: 'simple' });
     await page.click('.menu-btn');
     await page.waitForSelector('#game-hbg-menu.open');
@@ -1768,7 +1768,10 @@ test.describe('Batch fixes (#154-#158)', () => {
       }
       return null;
     });
-    expect(ruleValue).toContain('120px');
+    // Must include the safe-area inset variable AND whitespace around `+`
+    // (whitespace is required by the CSS calc() spec — WebKit silently rejects
+    // expressions like `calc(var(--x)+10px)`; see V2.56 hotfix).
+    expect(ruleValue).toMatch(/var\(--bottom-inset\)\s\+\s\d+px/);
   });
 
   // #157: Volume button JS handler dispatches correct action


### PR DESCRIPTION
## Summary
V2.55's `120px` was guessed from a baseline that — thanks to the calc() parse bug fixed in V2.56 — was silently zero. Now that the rule actually applies, that much padding is way too generous (visible 250-300px gap below Save/Share). Reduces to `calc(var(--bottom-inset) + 24px)` for a small, intentional cushion above the home indicator.

Also broadens the `#156` test to assert the rule includes `var(--bottom-inset)` with whitespace around `+` (the required form per CSS spec), rather than locking to a specific px value. Future tuning won't break the test, and it would now catch a regression of the V2.56 parse bug.

## Test plan
- [x] All 264 Playwright E2E tests pass locally
- [ ] Visual check on iPhone 17 sim: Save/Share sit comfortably above the home indicator with a small (~24px on top of safe-area) cushion, not floating in the middle of the screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)